### PR TITLE
providerFromEngine - server-push s1upport

### DIFF
--- a/providerFromEngine.js
+++ b/providerFromEngine.js
@@ -1,6 +1,11 @@
+const EventEmitter = require('events')
+
 module.exports = providerFromEngine
 
 function providerFromEngine (engine) {
-  const provider = { sendAsync: engine.handle.bind(engine) }
+  const provider = new EventEmitter()
+  provider.sendAsync = engine.handle.bind(engine)
+  // rebroadcast the 'data' event from engine to provider
+  engine.on('data', provider.emit.bind(provider, 'data'))
   return provider
 }


### PR DESCRIPTION
status: wip

requires engine to have some server-push support, e.g. an event emitting interface