### PR TITLE
don't pass the block number to eth_estimateGas

### DIFF
--- a/cache-utils.js
+++ b/cache-utils.js
@@ -61,7 +61,6 @@ function blockTagParamIndex (payload) {
     case 'eth_call':
       return 1
     // blockTag is at index 0
-    case 'eth_estimateGas':
     case 'eth_getBlockByNumber':
       return 0
     // there is no blockTag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-json-rpc-middleware",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "block-ref.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Two different issues found:
- Currently the blockTagIndex for eth_estimateGas 0, but that's not correct since the index 0 is the tx itself. That throws an exception [here](https://github.com/MetaMask/eth-json-rpc-middleware/blob/master/retryOnEmpty.js#L34) slice is not a function since it's an object (the TX)
(Can be reproduced [here](https://tmashuang.github.io/ropsten-contract/)

- After fixing the index I'm sending the right data to infura but still getting an RPC response error saying `too many arguments, want at most 1`

Because of this, I assume we don't have to pass the block number at all to the eth_estimageGas call.

With this PR both problems are fixed