### PR TITLE
Support ERC191 v0 signatures

### DIFF
--- a/wallet.js
+++ b/wallet.js
@@ -8,6 +8,7 @@ function createWalletMiddleware(opts = {}) {
   // parse + validate options
   const getAccounts = opts.getAccounts
   const processTypedMessage = opts.processTypedMessage
+  const processTypedMessageV0 = opts.processTypedMessageV0
   const processTypedMessageV3 = opts.processTypedMessageV3
   const processPersonalMessage = opts.processPersonalMessage
   const processEthSignMessage = opts.processEthSignMessage
@@ -22,6 +23,7 @@ function createWalletMiddleware(opts = {}) {
     // message signatures
     'eth_sign': createAsyncMiddleware(ethSign),
     'eth_signTypedData': createAsyncMiddleware(signTypedData),
+    'eth_signTypedData_v0': createAsyncMiddleware(signTypedDataV0),
     'eth_signTypedData_v3': createAsyncMiddleware(signTypedDataV3),
     'personal_sign': createAsyncMiddleware(personalSign),
     'personal_ecRecover': createAsyncMiddleware(personalRecover),
@@ -89,6 +91,22 @@ function createWalletMiddleware(opts = {}) {
     await validateSender(address, req)
     await validateSender(from, req)
     res.result = await processTypedMessage(msgParams, req, version)
+  }
+
+  async function signTypedDataV0 (req, res) {
+    if (!processTypedMessageV0) throw new Error('WalletMiddleware - opts.processTypedMessage not provided')
+    const from = req.from
+    const message = req.params[1]
+    const address = req.params[0]
+    const version = 'V0'
+    await validateSender(address, req)
+    await validateSender(from, req)
+    const msgParams = {
+      data: message,
+      from: address,
+      version
+    }
+    res.result = await processTypedMessageV0(msgParams, req, version)
   }
 
   async function signTypedDataV3 (req, res) {


### PR DESCRIPTION
Companion PR for [#5884 on `metamask-extension`](https://github.com/MetaMask/metamask-extension/pull/5884) adding support for [ERC191 v0](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-191.md) signatures via a new `eth_signTypedData_v0` RPC call.