### PR TITLE
Fix interal error handling

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -73,10 +73,10 @@ function checkForHttpErrors (fetchRes) {
 function parseResponse (fetchRes, body) {
   // check for error code
   if (fetchRes.status !== 200) {
-    throw rpcErrors.internal(body)
+    throw rpcErrors.internal(`Non-200 status code: '${fetchRes.status}'`, body)
   }
   // check for rpc error
-  if (body.error) throw rpcErrors.internal(body.error)
+  if (body.error) throw rpcErrors.internal(body.error.toString(), body.error)
   // return successful result
   return body.result
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14643,8 +14643,9 @@
       "dev": true
     },
     "json-rpc-engine": {
-      "version": "github:rekmarks/json-rpc-engine#6e639002b6bfa020b6b0effb2b60d93e6607f1f5",
-      "from": "github:rekmarks/json-rpc-engine#errors",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-5.1.3.tgz",
+      "integrity": "sha512-/rQm6uts6JtjOVEaeSDCJgHDTlbfKDdoR1Uh3f+6za2SwhJyz+jL9iED2aapU9Yx7decLlI7wjVUIwxRg/R7WQ==",
       "requires": {
         "async": "^2.0.1",
         "eth-json-rpc-errors": "^1.0.1",


### PR DESCRIPTION
`rpcErrors.internal` expects a string as the first argument, with arbitrary data being the optional second argument. Passing in a non-string first argument results in the error being shadowed by an error from eth-json-rpc-errors ('Error: "message" must be a nonempty string')