### PR TITLE
Fix: body.error.toString() returns "[object Object]"

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -80,7 +80,6 @@ function parseResponse (fetchRes, body) {
   }
   // check for rpc error
   if (body.error) throw ethErrors.rpc.internal({
-    message: body.error.toString(),
     data: body.error,
   })
   // return successful result


### PR DESCRIPTION
This only happens when using
1. eth-json-rpc-errors@2.0.0 with eth-json-rpc-middleware@4.4.0
2. eth-json-rpc-errors@1.1.0 with eth-json-rpc-middleware@4.4.0

This won't happens when using
eth-json-rpc-errors@1.1.0 with eth-json-rpc-middleware@4.2.0

Check comment bellow for more detail
https://github.com/MetaMask/metamask-extension/issues/7286#issuecomment-568405380