### PR TITLE
Normalize and require keyholder address

### DIFF
--- a/test/wallet.js
+++ b/test/wallet.js
@@ -38,15 +38,6 @@ accountsTest({
 //
 
 transactionTest({
-  testLabel: 'no address',
-  txParams: {
-    from: undefined,
-  },
-  accounts: testAddresses,
-  fromAddressIsValid: true,
-})
-
-transactionTest({
   testLabel: 'valid address',
   txParams: {
     from: testAddresses[0],
@@ -71,13 +62,6 @@ transactionTest({
 // eth_sign
 
 ethSignTest({
-  testLabel: 'eth_sign - no address',
-  address: null,
-  accounts: testAddresses.slice(),
-  fromAddressIsValid: true,
-})
-
-ethSignTest({
   testLabel: 'eth_sign - valid address',
   address: testAddresses[0],
   accounts: testAddresses.slice(),
@@ -94,13 +78,6 @@ ethSignTest({
 // eth_signTypedData
 
 ethSignTypedDataTest({
-  testLabel: 'eth_signTypedData - no address',
-  address: null,
-  accounts: testAddresses.slice(),
-  fromAddressIsValid: true,
-})
-
-ethSignTypedDataTest({
   testLabel: 'eth_signTypedData - valid address',
   address: testAddresses[0],
   accounts: testAddresses.slice(),
@@ -115,13 +92,6 @@ ethSignTypedDataTest({
 })
 
 // personal_sign
-
-personalSignTest({
-  testLabel: 'personal_sign - no address',
-  address: null,
-  accounts: testAddresses.slice(),
-  fromAddressIsValid: true,
-})
 
 personalSignTest({
   testLabel: 'personal_sign - valid address',
@@ -210,7 +180,7 @@ function ethSignTest({ testLabel, address, accounts, fromAddressIsValid }) {
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid "from" address.')) {
+      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -254,7 +224,7 @@ function ethSignTypedDataTest({ testLabel, address, accounts, fromAddressIsValid
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid "from" address.')) {
+      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -292,7 +262,7 @@ function personalSignTest({ testLabel, address, accounts, fromAddressIsValid }) 
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid "from" address.')) {
+      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -328,7 +298,7 @@ function transactionTest({ testLabel, txParams, accounts, fromAddressIsValid }) 
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid "from" address.')) {
+      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)


### PR DESCRIPTION
### Terminology

What I call the "keyholder" address has previously been referred to as the "from" address and "sender" address. "from" and "sender" are misnomers, because the address simply needs to refer to an account controlled by MetaMask, whose private key is needed to perform some operation. Sometimes, this address is the recipient of a message. Other times, it is the sender/signer of a message.

Thus, "keyholder."

### Summary of Changes

- Require keyholder addresses wherever they are required in practice
- Validate _and_ normalize keyholder addresses whenever they are provided

### Changes in Detail

- Require keyholder addresses wherever they are required in practice
- Validate _and_ normalize keyholder addresses whenever they are provided
  - `validateSender` has been renamed to `validateAndNormalizeKeyholder`, and fulfills both purposes
  - Previously, the address would only be validated if provided. A valid address is now required.
  - Previously, the address would be normalized (i.e. lowercased) during validation without being overwritten. We now pass the normalized address to the extension if validation succeeds.
    - Note that we don't overwrite the parameters themselves; we only normalize the address value we use internally to identify the keyholder account.
- Update tests to reflect the above changes. All tests pass.

This PR will be followed by standardization PRs and a major version bump.