### PR TITLE
Update wallet middleware errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "btoa": "^1.2.1",
     "clone": "^2.1.1",
-    "eth-json-rpc-errors": "^1.0.1",
     "eth-query": "^2.1.2",
+    "eth-rpc-errors": "^2.1.1",
     "eth-sig-util": "^1.4.2",
     "ethereumjs-block": "^1.6.0",
     "ethereumjs-tx": "^1.3.7",

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -180,7 +180,7 @@ function ethSignTest({ testLabel, address, accounts, fromAddressIsValid }) {
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
+      if (!fromAddressIsValid && err.message.includes('Invalid parameters: must provide an Ethereum address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -224,7 +224,7 @@ function ethSignTypedDataTest({ testLabel, address, accounts, fromAddressIsValid
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
+      if (!fromAddressIsValid && err.message.includes('Invalid parameters: must provide an Ethereum address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -262,7 +262,7 @@ function personalSignTest({ testLabel, address, accounts, fromAddressIsValid }) 
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
+      if (!fromAddressIsValid && err.message.includes('Invalid parameters: must provide an Ethereum address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)
@@ -298,7 +298,7 @@ function transactionTest({ testLabel, txParams, accounts, fromAddressIsValid }) 
         t.fail('should have validated that fromAddress is invalid')
       }
     } catch (err) {
-      if (!fromAddressIsValid && err.message.includes('WalletMiddleware - Invalid keyholder address.')) {
+      if (!fromAddressIsValid && err.message.includes('Invalid parameters: must provide an Ethereum address.')) {
         t.pass('correctly errored on invalid sender.')
       } else {
         t.ifError(err)

--- a/wallet.js
+++ b/wallet.js
@@ -1,6 +1,7 @@
 const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
 const createScaffoldMiddleware = require('json-rpc-engine/src/createScaffoldMiddleware')
 const sigUtil = require('eth-sig-util')
+const { ethErrors } = require('eth-rpc-errors')
 
 module.exports = function createWalletMiddleware(opts = {}) {
   // parse + validate options
@@ -15,7 +16,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   const processEncryptionPublicKey = opts.processEncryptionPublicKey
 
   if (!getAccounts) {
-    throw new Error('WalletMiddleware - opts.getAccounts not provided')
+    throw new Error('opts.getAccounts is required')
   }
 
   return createScaffoldMiddleware({
@@ -55,7 +56,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function sendTransaction(req, res) {
 
     if (!processTransaction) {
-      throw new Error('WalletMiddleware - opts.processTransaction not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const txParams = req.params[0] || {}
@@ -70,7 +71,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function ethSign(req, res) {
 
     if (!processEthSignMessage) {
-      throw new Error('WalletMiddleware - opts.processEthSignMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const address = await validateAndNormalizeKeyholder(req.params[0], req)
@@ -87,7 +88,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function signTypedData (req, res) {
 
     if (!processTypedMessage) {
-      throw new Error('WalletMiddleware - opts.processTypedMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const message = req.params[0]
@@ -105,7 +106,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function signTypedDataV3 (req, res) {
 
     if (!processTypedMessageV3) {
-      throw new Error('WalletMiddleware - opts.processTypedMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const address = await validateAndNormalizeKeyholder(req.params[0], req)
@@ -123,7 +124,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function signTypedDataV4 (req, res) {
 
     if (!processTypedMessageV4) {
-      throw new Error('WalletMiddleware - opts.processTypedMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const address = await validateAndNormalizeKeyholder(req.params[0], req)
@@ -141,7 +142,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function personalSign (req, res) {
 
     if (!processPersonalMessage) {
-      throw new Error('WalletMiddleware - opts.processPersonalMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     // process normally
@@ -198,7 +199,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function encryptionPublicKey (req, res) {
 
     if (!processEncryptionPublicKey) {
-      throw new Error('WalletMiddleware - opts.processEncryptionPublicKey not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const address = await validateAndNormalizeKeyholder(req.params[0], req)
@@ -209,7 +210,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
   async function decryptMessage (req, res) {
 
     if (!processDecryptMessage) {
-      throw new Error('WalletMiddleware - opts.processDecryptMessage not provided')
+      throw ethErrors.rpc.methodNotSupported()
     }
 
     const ciphertext = req.params[0]
@@ -249,7 +250,9 @@ module.exports = function createWalletMiddleware(opts = {}) {
         return normalizedAddress
       }
     }
-    throw new Error('WalletMiddleware - Invalid keyholder address.')
+    throw ethErrors.rpc.invalidParams({
+      message: `Invalid parameters: must provide an Ethereum address.`
+    })
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,13 @@ eth-query@^2.0.2, eth-query@^2.1.0, eth-query@^2.1.2:
     json-rpc-random-id "^1.0.0"
     xtend "^4.0.1"
 
+eth-rpc-errors@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
+  integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-sig-util@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/eth-sig-util/-/eth-sig-util-2.2.0.tgz#769fa3d296b450f6618dedeefe076642c923a16f"


### PR DESCRIPTION
- Add `eth-rpc-errors`
- Replace wallet middleware errors with `eth-rpc-errors` where appropriate
  - Update tests
- Update fetch middleware to use `eth-rpc-errors` instead of `eth-json-rpc-errors`, which is deprecated
- Remove `eth-json-rpc-errors`