### PR TITLE
Normalize from address in sendTransaction

### DIFF
--- a/wallet.js
+++ b/wallet.js
@@ -60,7 +60,7 @@ module.exports = function createWalletMiddleware(opts = {}) {
     }
 
     const txParams = req.params[0] || {}
-    await validateAndNormalizeKeyholder(txParams.from, req)
+    txParams.from = await validateAndNormalizeKeyholder(txParams.from, req)
     res.result = await processTransaction(txParams, req)
   }
 


### PR DESCRIPTION
Somehow, we failed to actually normalize the `params.from` address in `sendTransaction` in #29, even though this was definitively our intention.

This has now been fixed.