### PR TITLE
Use node-fetch directly as ponyfill

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,4 +1,4 @@
-const fetch = global.fetch || require('fetch-ponyfill')().fetch
+const fetch = global.fetch || require('node-fetch')
 const url = require('url')
 const { ethErrors } = require('eth-rpc-errors')
 const btoa = require('btoa')

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^5.1.2",
     "ethereumjs-vm": "^2.6.0",
-    "fetch-ponyfill": "^4.0.0",
     "json-rpc-engine": "^5.1.3",
     "json-stable-stringify": "^1.0.1",
+    "node-fetch": "^2.6.1",
     "pify": "^3.0.0",
     "safe-event-emitter": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,6 +4476,11 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@~1.7.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"


### PR DESCRIPTION
This change replaces `fetch-ponyfill` with `node-fetch`, as the ponyfill was only used when the a global `fetch` did not exist—i.e. not a browser context.

`fetch-ponyfill@^4` was using `node-fetch@^1` and this updates `node-fetch` to the latest version, `^2` (2.6.1). Per its changes:

> - Major: Node.js 0.10.x and 0.12.x support is dropped
> - Major: require('node-fetch/lib/response') etc. is now unsupported; use require('node-fetch').Response or ES6 module imports

While this is _technically_ a breaking change, Node.js 0.10.x was discontinued on 2016-10-31 and 0.12.x on 2016-12-31, and this codebase does not work with either of these versions:<sup>[\[1\]][1]</sup>

  [1]:https://node.green

- 0.12.x does not support template literals
- 0.12.x does not support destructuring declarations

Both of which we use.

I suggest this is a patch version bump.

---

This change also resolves a security advisory against old `node-fetch` versions.

See https://www.npmjs.com/advisories/1556 for more information.

The `yarn audit` output:

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ node-fetch                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.6.1 <3.0.0-beta.1|| >= 3.0.0-beta.9                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ fetch-ponyfill                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ fetch-ponyfill > node-fetch                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1556                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
```