### PR TITLE
Replace 'url' dependency with native URL global

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "eth-json-rpc-middleware",
   "version": "6.0.0",
   "main": "block-ref.js",
+  "engines": {
+    "node": ">=10.0.0"
+  },
   "directories": {
     "test": "test"
   },

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,4 +1,3 @@
-const url = require('url')
 const { ethErrors } = require('eth-rpc-errors')
 const btoa = require('btoa')
 const createAsyncMiddleware = require('json-rpc-engine/src/createAsyncMiddleware')
@@ -93,8 +92,7 @@ function parseResponse (fetchRes, body) {
 }
 
 function createFetchConfigFromReq ({ req, rpcUrl, originHttpHeaderKey }) {
-  // eslint-disable-next-line node/no-deprecated-api
-  const parsedUrl = url.parse(rpcUrl)
+  const parsedUrl = new URL(rpcUrl)
   const fetchUrl = normalizeUrlFromParsed(parsedUrl)
 
   // prepare payload

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -68,6 +68,7 @@ function checkForHttpErrors (fetchRes) {
     case 503:
     case 504:
       throw createTimeoutError()
+
     default:
       break
   }
@@ -92,6 +93,7 @@ function parseResponse (fetchRes, body) {
 }
 
 function createFetchConfigFromReq ({ req, rpcUrl, originHttpHeaderKey }) {
+
   const parsedUrl = new URL(rpcUrl)
   const fetchUrl = normalizeUrlFromParsed(parsedUrl)
 
@@ -121,8 +123,9 @@ function createFetchConfigFromReq ({ req, rpcUrl, originHttpHeaderKey }) {
   }
 
   // encoded auth details as header (not allowed in fetch url)
-  if (parsedUrl.auth) {
-    const encodedAuth = btoa(parsedUrl.auth)
+  if (parsedUrl.username && parsedUrl.password) {
+    const authString = `${parsedUrl.username}:${parsedUrl.password}`
+    const encodedAuth = btoa(authString)
     fetchParams.headers.Authorization = `Basic ${encodedAuth}`
   }
 
@@ -137,14 +140,11 @@ function createFetchConfigFromReq ({ req, rpcUrl, originHttpHeaderKey }) {
 function normalizeUrlFromParsed (parsedUrl) {
   let result = ''
   result += parsedUrl.protocol
-  if (parsedUrl.slashes) {
-    result += '//'
-  }
-  result += parsedUrl.hostname
+  result += `//${parsedUrl.hostname}`
   if (parsedUrl.port) {
     result += `:${parsedUrl.port}`
   }
-  result += `${parsedUrl.path}`
+  result += `${parsedUrl.pathname}`
   return result
 }
 


### PR DESCRIPTION
We should just use the native URL global whenever we deal with URLs.
closes #64 