### PR TITLE
Fix package export and `files` manifest property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eth-json-rpc-middleware",
   "version": "6.0.0",
-  "main": "block-ref.js",
+  "main": "./src/block-ref.js",
   "engines": {
     "node": ">=10.0.0"
   },
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "files": [
-    "*.js"
+    "src/*.js"
   ],
   "devDependencies": {
     "@metamask/eslint-config": "^4.1.0",


### PR DESCRIPTION
The main export of the package was broken in #60 when the source files were moved into the `src` directory, because the path of the `main` property was not updated accordingly. This updates `main` to point at the new location of the `block-ref` module.

Any modules referenced by file will still be in different locations now (e.g. `require('eth-json-rpc-middleware/block-ref`) will have to be changed to `require('eth-json-rpc-middleware/src/block-ref`), so #60 will still need to be treated as a breaking change. But at least the main export works now.

The `files` property of the manifest was also broken in #60. It has been updated to correctly reference all of the JavaScript modules that should be published.