### PR TITLE
Block cache "set" method returns early for a null/ undefined identifier.

### DIFF
--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -68,7 +68,10 @@ class BlockCacheStrategy {
     // set the value in the cache
     const blockCache: BlockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber);
     const identifier: string|null = cacheIdentifierForPayload(payload, true);
-    blockCache[identifier as any] = result;
+    if (!identifier) {
+      return;
+    }
+    blockCache[identifier] = result;
   }
 
   canCacheRequest(payload: Payload): boolean {

--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -66,11 +66,11 @@ class BlockCacheStrategy {
     }
 
     // set the value in the cache
-    const blockCache: BlockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber);
     const identifier: string|null = cacheIdentifierForPayload(payload, true);
     if (!identifier) {
       return;
     }
+    const blockCache: BlockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber);
     blockCache[identifier] = result;
   }
 


### PR DESCRIPTION
fixes : #73 

In the block-cache middleware, the set function is updated to return early if the identifier is not found (null/undefined)