### PR TITLE
Fix DOM TypeScript library usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,9 +18,6 @@ module.exports = {
       extends: [
         '@metamask/eslint-config/config/typescript',
       ],
-      rules: {
-        'spaced-comment': ['error', 'always', { 'markers': ['/'] }],
-      },
     },
     {
       files: [

--- a/src/inflight-cache.ts
+++ b/src/inflight-cache.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import clone from 'clone';
 import {
   createAsyncMiddleware,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "inlineSources": true,
-    "lib": ["ES2017"],
+    "lib": ["DOM", "ES2017"],
     "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "dist",


### PR DESCRIPTION
This removes the triple-slash directive to use the TypeScript DOM lib and puts it in `tsconfig.json` where it belongs. I thought the triple-slash directive add the given lib on a per-file basis, but it adds it for the entire project. Lame!

This also allowed us to remove an override from the eslint config.