### PR TITLE
Ignore btoa dependency in browser environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # eth-json-rpc-middleware
 
-Ethereum related middleware for [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
+Ethereum-related middleware for [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
 
 See tests for usage details.
 
-### see also
+## See Also
 
 - [`eth-json-rpc-filters`](https://github.com/MetaMask/eth-json-rpc-filters).
 - [`eth-json-rpc-infura`](https://github.com/MetaMask/json-rpc-infura).
 - [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
-- (semi-deprecated) [`provider-engine`](https://github.com/MetaMask/provider-engine)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # eth-json-rpc-middleware
 
-Ethereum-related middleware for [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
+Ethereum related middleware for [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
 
 See tests for usage details.
 
-## See Also
+### see also
 
 - [`eth-json-rpc-filters`](https://github.com/MetaMask/eth-json-rpc-filters).
 - [`eth-json-rpc-infura`](https://github.com/MetaMask/json-rpc-infura).
 - [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
+- (semi-deprecated) [`provider-engine`](https://github.com/MetaMask/provider-engine)

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "eth-json-rpc-middleware",
+  "description": "Ethereum-related json-rpc-engine middleware.",
   "version": "6.0.0",
-  "main": "./dist/block-ref.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "browser": {
-    "node-fetch": false
+    "node-fetch": false,
+    "btoa": false
   },
   "engines": {
     "node": ">=10.0.0"
@@ -18,11 +21,23 @@
     "test:nobuild": "node test/index.js",
     "test": "yarn build && yarn test:nobuild"
   },
-  "author": "",
   "license": "ISC",
   "files": [
     "dist/"
   ],
+  "dependencies": {
+    "@metamask/safe-event-emitter": "^2.0.0",
+    "btoa": "^1.2.1",
+    "clone": "^2.1.1",
+    "eth-query": "^2.1.2",
+    "eth-rpc-errors": "^4.0.3",
+    "eth-sig-util": "^1.4.2",
+    "ethereumjs-util": "^5.1.2",
+    "json-rpc-engine": "^6.1.0",
+    "json-stable-stringify": "^1.0.1",
+    "node-fetch": "^2.6.1",
+    "pify": "^3.0.0"
+  },
   "devDependencies": {
     "@metamask/eslint-config": "^5.0.0",
     "@types/btoa": "^1.2.3",
@@ -45,24 +60,12 @@
     "tape": "^4.6.3",
     "typescript": "^4.1.3"
   },
-  "dependencies": {
-    "@metamask/safe-event-emitter": "^2.0.0",
-    "btoa": "^1.2.1",
-    "clone": "^2.1.1",
-    "eth-rpc-errors": "^4.0.3",
-    "eth-sig-util": "^1.4.2",
-    "json-rpc-engine": "^6.1.0",
-    "json-stable-stringify": "^1.0.1",
-    "node-fetch": "^2.6.1",
-    "pify": "^3.0.0"
-  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kumavis/eth-json-rpc-middleware.git"
+    "url": "git+https://github.com/MetaMask/eth-json-rpc-middleware.git"
   },
   "bugs": {
-    "url": "https://github.com/kumavis/eth-json-rpc-middleware/issues"
+    "url": "https://github.com/MetaMask/eth-json-rpc-middleware/issues"
   },
-  "homepage": "https://github.com/kumavis/eth-json-rpc-middleware#readme",
-  "description": ""
+  "homepage": "https://github.com/MetaMask/eth-json-rpc-middleware#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
   "name": "eth-json-rpc-middleware",
-  "description": "Ethereum-related json-rpc-engine middleware.",
   "version": "6.0.0",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/block-ref.js",
   "browser": {
     "node-fetch": false,
     "btoa": false
@@ -21,23 +19,11 @@
     "test:nobuild": "node test/index.js",
     "test": "yarn build && yarn test:nobuild"
   },
+  "author": "",
   "license": "ISC",
   "files": [
     "dist/"
   ],
-  "dependencies": {
-    "@metamask/safe-event-emitter": "^2.0.0",
-    "btoa": "^1.2.1",
-    "clone": "^2.1.1",
-    "eth-query": "^2.1.2",
-    "eth-rpc-errors": "^4.0.3",
-    "eth-sig-util": "^1.4.2",
-    "ethereumjs-util": "^5.1.2",
-    "json-rpc-engine": "^6.1.0",
-    "json-stable-stringify": "^1.0.1",
-    "node-fetch": "^2.6.1",
-    "pify": "^3.0.0"
-  },
   "devDependencies": {
     "@metamask/eslint-config": "^5.0.0",
     "@types/btoa": "^1.2.3",
@@ -60,12 +46,24 @@
     "tape": "^4.6.3",
     "typescript": "^4.1.3"
   },
+  "dependencies": {
+    "@metamask/safe-event-emitter": "^2.0.0",
+    "btoa": "^1.2.1",
+    "clone": "^2.1.1",
+    "eth-rpc-errors": "^4.0.3",
+    "eth-sig-util": "^1.4.2",
+    "json-rpc-engine": "^6.1.0",
+    "json-stable-stringify": "^1.0.1",
+    "node-fetch": "^2.6.1",
+    "pify": "^3.0.0"
+  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MetaMask/eth-json-rpc-middleware.git"
+    "url": "git+https://github.com/kumavis/eth-json-rpc-middleware.git"
   },
   "bugs": {
-    "url": "https://github.com/MetaMask/eth-json-rpc-middleware/issues"
+    "url": "https://github.com/kumavis/eth-json-rpc-middleware/issues"
   },
-  "homepage": "https://github.com/MetaMask/eth-json-rpc-middleware#readme"
+  "homepage": "https://github.com/kumavis/eth-json-rpc-middleware#readme",
+  "description": ""
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,10 +1,11 @@
 import { createAsyncMiddleware, JsonRpcMiddleware } from 'json-rpc-engine';
 import { EthereumRpcError, ethErrors } from 'eth-rpc-errors';
-import btoa from 'btoa';
 import { Payload, Block } from './cache-utils';
 
-// eslint-disable-next-line node/global-require,@typescript-eslint/no-require-imports
+/* eslint-disable node/global-require,@typescript-eslint/no-require-imports */
 const fetch = global.fetch || require('node-fetch');
+const btoa = global.btoa || require('btoa');
+/* eslint-enable node/global-require,@typescript-eslint/no-require-imports */
 
 const RETRIABLE_ERRORS: string[] = [
   // ignore server overload errors


### PR DESCRIPTION
Ensures that appropriately configured bundlers ignores the `btoa` dependency in favor of the browser implementation in browser environments.