### PR TITLE
Fix blockTrackerInspectorMiddleware

### DIFF
--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -38,6 +38,6 @@ export function createBlockTrackerInspectorMiddleware({
         await blockTracker.checkForLatestBlock();
       }
     }
-    return next();
+    return undefined;
   });
 }


### PR DESCRIPTION
The final line of this middleware should be `return undefined;`, not `return await next();`, as `next()` is already called earlier in the function.