### PR TITLE
add support for send call with callback so that Web3 Providers can be used

### DIFF
--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -20,3 +20,23 @@ export function providerAsMiddleware(
     );
   };
 }
+
+export function ethersProviderAsMiddleware(
+  provider: SafeEventEmitterProvider,
+): JsonRpcMiddleware<string[], Block> {
+  return (req, res, _next, end) => {
+    // send request to provider
+    provider.send(
+      req,
+      (err: Error, providerRes: PendingJsonRpcResponse<Block>) => {
+        // forward any error
+        if (err) {
+          return end(err);
+        }
+        // copy provider response onto original response
+        Object.assign(res, providerRes);
+        return end();
+      },
+    );
+  };
+}

--- a/src/providerFromEngine.ts
+++ b/src/providerFromEngine.ts
@@ -8,7 +8,7 @@ export function providerFromEngine(
   const provider: SafeEventEmitterProvider = new SafeEventEmitter() as SafeEventEmitterProvider;
   // handle both rpc send methods
   provider.sendAsync = engine.handle.bind(engine);
-  provider.send = (req: JsonRpcRequest<string[]>, callback: () => void) => {
+  provider.send = (req: JsonRpcRequest<string[]>, callback: (error: any, providerRes: any) => void) => {
     if (typeof callback !== 'function') {
       throw new Error('Must provide callback to "send" method.');
     }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -21,12 +21,17 @@ export type SendAsyncCallBack = (
   providerRes: PendingJsonRpcResponse<Block>
 ) => void;
 
+export type SendCallBack = (
+  err: any,
+  providerRes: any
+) => void;
+
 export interface SafeEventEmitterProvider extends SafeEventEmitter {
   sendAsync: (
     req: JsonRpcRequest<string[]>,
     callback: SendAsyncCallBack
   ) => void;
-  send: (req: JsonRpcRequest<string[]>, callback: () => void) => void;
+  send: (req: JsonRpcRequest<string[]>, callback: SendCallBack) => void;
 }
 
 export function cacheIdentifierForPayload(


### PR DESCRIPTION
Creating a pull request off from pull request #96 as both the requests are independent changes. This request is to add support for adding Web3 providers as middleware which requires calling `send` instead of `sendAsync`. The existing `send` interface is missing the callback argument.
Please refer to pull request #96 for original discussion.