### PR TITLE
chore: replace json-stable-stringify with safe-stable-stringify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replace `fast-stable-stringify` dependency with `safe-stable-stringify`
 
 ## [10.0.0]
 ### Changed

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "eth-block-tracker": "^6.1.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
-    "json-stable-stringify": "^1.0.1",
-    "pify": "^3.0.0"
+    "pify": "^3.0.0",
+    "safe-stable-stringify": "^2.3.2"
   },
   "devDependencies": {
     "@jest/globals": "^27.5.1",
@@ -49,7 +49,6 @@
     "@types/btoa": "^1.2.3",
     "@types/clone": "^2.1.0",
     "@types/jest": "^27.4.1",
-    "@types/json-stable-stringify": "^1.0.32",
     "@types/node": "^17.0.23",
     "@types/pify": "^3.0.2",
     "@typescript-eslint/eslint-plugin": "^4.21.0",

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,5 +1,7 @@
-import stringify from 'json-stable-stringify';
+import { configure } from 'safe-stable-stringify';
 import { JsonRpcRequest } from 'json-rpc-engine';
+
+const stringify = configure({ bigint: false, circularValue: Error });
 
 /**
  * The cache strategy to use for a given method.

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,7 +862,6 @@ __metadata:
     "@types/btoa": ^1.2.3
     "@types/clone": ^2.1.0
     "@types/jest": ^27.4.1
-    "@types/json-stable-stringify": ^1.0.32
     "@types/node": ^17.0.23
     "@types/pify": ^3.0.2
     "@typescript-eslint/eslint-plugin": ^4.21.0
@@ -878,11 +877,11 @@ __metadata:
     eth-rpc-errors: ^4.0.3
     jest: ^27.5.1
     json-rpc-engine: ^6.1.0
-    json-stable-stringify: ^1.0.1
     pify: ^3.0.0
     prettier: ^2.2.1
     prettier-plugin-packagejson: ^2.2.11
     rimraf: ^3.0.2
+    safe-stable-stringify: ^2.3.2
     ts-jest: ^27.1.4
     ts-node: ^10.7.0
     typescript: ~4.2.4
@@ -1223,13 +1222,6 @@ __metadata:
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
   checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
-  languageName: node
-  linkType: hard
-
-"@types/json-stable-stringify@npm:^1.0.32":
-  version: 1.0.34
-  resolution: "@types/json-stable-stringify@npm:1.0.34"
-  checksum: 45767ecef0f6aae5680c3be6488d5c493f16046e34f182d7e6a2c69a667aab035799752c6f03017c883b134ad3f80e3f78d7e7da81a9c1f3d01676126baf5d0e
   languageName: node
   linkType: hard
 
@@ -4456,15 +4448,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stable-stringify@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "json-stable-stringify@npm:1.0.1"
-  dependencies:
-    jsonify: ~0.0.0
-  checksum: 65d6cbf0fca72a4136999f65f4401cf39a129f7aeff0fdd987ac3d3423a2113659294045fb8377e6e20d865cac32b1b8d70f3d87346c9786adcee60661d96ca5
-  languageName: node
-  linkType: hard
-
 "json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
@@ -4489,13 +4472,6 @@ __metadata:
   bin:
     json5: lib/cli.js
   checksum: 866458a8c58a95a49bef3adba929c625e82532bcff1fe93f01d29cb02cac7c3fe1f4b79951b7792c2da9de0b32871a8401a6e3c5b36778ad852bf5b8a61165d7
-  languageName: node
-  linkType: hard
-
-"jsonify@npm:~0.0.0":
-  version: 0.0.0
-  resolution: "jsonify@npm:0.0.0"
-  checksum: d8d4ed476c116e6987a460dcb82f22284686caae9f498ac87b0502c1765ac1522f4f450a4cad4cc368d202fd3b27a3860735140a82867fc6d558f5f199c38bce
   languageName: node
   linkType: hard
 
@@ -5545,6 +5521,13 @@ __metadata:
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.2":
+  version: 2.4.2
+  resolution: "safe-stable-stringify@npm:2.4.2"
+  checksum: 0324ba2e40f78cae63e31a02b1c9bdf1b786621f9e8760845608eb9e81aef401944ac2078e5c9c1533cf516aea34d08fa8052ca853637ced84b791caaf1e394e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a performance improvement as the latter is actually faster.

json-stable-stringify x 13,870 ops/sec ±0.72% (94 runs sampled)
safe-stable-stringify x 30,367 ops/sec ±0.39% (96 runs sampled)

The only difference is that objects with circular reference are from
now on also accepted instead of throwing an error.