### PR TITLE
Add sendCredentials option to createFetchMiddleware

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -25,6 +25,7 @@ interface Request {
   method: string;
   headers: Record<string, string>;
   body: string;
+  credentials?: 'include' | 'omit' | 'same-origin';
 }
 interface FetchConfig {
   fetchUrl: string;
@@ -33,6 +34,7 @@ interface FetchConfig {
 interface FetchMiddlewareOptions {
   rpcUrl: string;
   originHttpHeaderKey?: string;
+  sendCredentials?: boolean;
 }
 
 interface FetchMiddlewareFromReqOptions extends FetchMiddlewareOptions {
@@ -42,12 +44,14 @@ interface FetchMiddlewareFromReqOptions extends FetchMiddlewareOptions {
 export function createFetchMiddleware({
   rpcUrl,
   originHttpHeaderKey,
+  sendCredentials,
 }: FetchMiddlewareOptions): JsonRpcMiddleware<string[], Block> {
   return createAsyncMiddleware(async (req, res, _next) => {
     const { fetchUrl, fetchParams } = createFetchConfigFromReq({
       req,
       rpcUrl,
       originHttpHeaderKey,
+      sendCredentials,
     });
 
     // attempt request multiple times
@@ -129,6 +133,7 @@ export function createFetchConfigFromReq({
   req,
   rpcUrl,
   originHttpHeaderKey,
+  sendCredentials,
 }: FetchMiddlewareFromReqOptions): FetchConfig {
   const parsedUrl: URL = new URL(rpcUrl);
   const fetchUrl: string = normalizeUrlFromParsed(parsedUrl);
@@ -168,6 +173,10 @@ export function createFetchConfigFromReq({
   // optional: add request origin as header
   if (originHttpHeaderKey && originDomain) {
     fetchParams.headers[originHttpHeaderKey] = originDomain;
+  }
+
+  if (sendCredentials === true) {
+    fetchParams.credentials = 'include';
   }
 
   return { fetchUrl, fetchParams };

--- a/test/fetch.js
+++ b/test/fetch.js
@@ -56,6 +56,31 @@ test('fetch - origin header', (t) => {
   t.end();
 });
 
+test('fetch - send credentials', (t) => {
+  const req = {
+    method: 'eth_getBlockByNumber',
+    params: ['0x482103', true],
+  };
+  const rpcUrl = 'http://www.xyz.io/rabbit:3456?id=100';
+  const { fetchUrl, fetchParams } = createFetchConfigFromReq({
+    req,
+    rpcUrl,
+    sendCredentials: true,
+  });
+
+  t.equals(fetchUrl, rpcUrl);
+  t.deepEquals(fetchParams, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(req),
+    credentials: 'include',
+  });
+  t.end();
+});
+
 test('fetch - auth in url', (t) => {
   const req = {
     method: 'eth_getBlockByNumber',


### PR DESCRIPTION
createFetchMiddleware doesn't support calling into am Eth JSON RPC Node that's protected by cookie-based
authentication. The standard approach to solving this is to tell fetch to send cookies along with CORS
requests. This change adds a sendCredentials option to createFetchMiddleware that, when set to true,
indicates cookies to be send for CORS requests.