### PR TITLE
Update block-ref to not make duplicate request

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,34 +3,6 @@ module.exports = {
 
   extends: ['@metamask/eslint-config'],
 
-  rules: {
-    // This makes integration tests easier to read by allowing setup code and
-    // assertions to be grouped together better
-    'padding-line-between-statements': [
-      'error',
-      {
-        blankLine: 'always',
-        prev: 'directive',
-        next: '*',
-      },
-      {
-        blankLine: 'any',
-        prev: 'directive',
-        next: 'directive',
-      },
-      {
-        blankLine: 'always',
-        prev: 'multiline-block-like',
-        next: '*',
-      },
-      {
-        blankLine: 'always',
-        prev: '*',
-        next: 'multiline-block-like',
-      },
-    ],
-  },
-
   overrides: [
     {
       files: ['*.ts'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,34 @@ module.exports = {
 
   extends: ['@metamask/eslint-config'],
 
+  rules: {
+    // This makes integration tests easier to read by allowing setup code and
+    // assertions to be grouped together better
+    'padding-line-between-statements': [
+      'error',
+      {
+        blankLine: 'always',
+        prev: 'directive',
+        next: '*',
+      },
+      {
+        blankLine: 'any',
+        prev: 'directive',
+        next: 'directive',
+      },
+      {
+        blankLine: 'always',
+        prev: 'multiline-block-like',
+        next: '*',
+      },
+      {
+        blankLine: 'always',
+        prev: '*',
+        next: 'multiline-block-like',
+      },
+    ],
+  },
+
   overrides: [
     {
       files: ['*.ts'],

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -1,59 +1,392 @@
+import { isDeepStrictEqual } from 'util';
 import { PollingBlockTracker, Provider } from 'eth-block-tracker';
-import { JsonRpcEngine } from 'json-rpc-engine';
-import pify from 'pify';
-import { providerFromEngine, createBlockRefMiddleware } from '.';
+import {
+  JsonRpcEngine,
+  JsonRpcMiddleware,
+  JsonRpcRequest,
+  JsonRpcResponse,
+} from 'json-rpc-engine';
+import clone from 'clone';
+import {
+  SafeEventEmitterProvider,
+  providerFromEngine,
+  createBlockRefMiddleware,
+} from '.';
 
-const testAddresses = [
-  '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  '0x1234362ef32bcd26d3dd18ca749378213625ba0b',
-];
+/**
+ * Objects used in each test.
+ *
+ * @property engine - The engine that holds the middleware stack, including the
+ * one being tested.
+ * @property provider - The provider that is used to make requests against
+ * (which the middleware being tested will react to).
+ * @property blockTracker - The block tracker which is used inside of the
+ * middleware being tested.
+ */
+interface Setup {
+  engine: JsonRpcEngine;
+  provider: SafeEventEmitterProvider;
+  blockTracker: PollingBlockTracker;
+}
 
-function createTestSetup() {
-  // raw data source
-  // create block tracker
-  // create higher level
+/**
+ * The function that `withTestSetup` is expected to take and will call once the
+ * setup objects are created.
+ */
+type WithTestSetupCallback<T> = (setup: Setup) => Promise<T>;
+
+/**
+ * An object that can be used to assign a canned response to a request (or an
+ * object that can be used to match a request) made via `provider.sendAsync`.
+ *
+ * @property request - An object that represents a JsonRpcRequest. Keys such as
+ * `id` or `jsonrpc` may be omitted if you don't care about them.
+ * @property response - A function that returns a JsonRpcResponse for that
+ * request. This function takes two arguments: the *real* request and a
+ * `callNumber`, which is the number of times the request has been made
+ * (counting the first request as 1). This latter argument be used to specify
+ * different responses for different instances of the same request.
+ * @property remainAfterUse - Usually, when a request is made via
+ * `provider.sendAsync`, the ProviderRequestStub which matches that request is
+ * removed from the list of stubs, so that if the same request comes through
+ * again, there will be no matching stub and an error will be thrown. This
+ * feature is useful for making sure that all requests have canned responses.
+ */
+interface ProviderRequestStub<T, U> {
+  request: Partial<JsonRpcRequest<T>>;
+  response: (
+    request: JsonRpcRequest<T>,
+    callNumber: number,
+  ) => JsonRpcResponse<U>;
+  remainAfterUse?: boolean;
+}
+
+describe('createBlockRefMiddleware', () => {
+  // This list corresponds to the list in the `blockTagParamIndex` function
+  // within `src/utils/cache.ts`
+  (
+    [
+      { blockParamIndex: 0, methods: ['eth_getBlockByNumber'] },
+      {
+        blockParamIndex: 1,
+        methods: [
+          'eth_getBalance',
+          'eth_getCode',
+          'eth_getTransactionCount',
+          'eth_call',
+        ],
+      },
+      { blockParamIndex: 2, methods: ['eth_getStorageAt'] },
+    ] as const
+  ).forEach(({ blockParamIndex, methods }) => {
+    methods.forEach((method: string) => {
+      describe(`when the RPC method is ${method}`, () => {
+        it('replaces the block param with the latest block number before proceeding to the next middleware if the block param is "latest"', async () => {
+          await withTestSetup(async ({ engine, provider, blockTracker }) => {
+            engine.push(createBlockRefMiddleware({ provider, blockTracker }));
+            const middleware = buildFinalMiddlewareWithDefaultResponse();
+            engine.push(middleware);
+            stubProviderRequests(provider, [stubBlockNumberRequest('0x100')]);
+
+            await engine.handle({
+              jsonrpc: '2.0',
+              id: 1,
+              method,
+              params: buildMockParamsWithBlockParamAt(
+                blockParamIndex,
+                'latest',
+              ),
+            });
+
+            expect(middleware).toHaveBeenCalledWith(
+              expect.objectContaining({
+                params: buildMockParamsWithBlockParamAt(
+                  blockParamIndex,
+                  '0x100',
+                ),
+              }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything(),
+            );
+          });
+        });
+
+        it('replaces the block param with the latest block number before proceeding to the next middleware if no block param is provided', async () => {
+          await withTestSetup(async ({ engine, provider, blockTracker }) => {
+            engine.push(createBlockRefMiddleware({ provider, blockTracker }));
+            const middleware = buildFinalMiddlewareWithDefaultResponse();
+            engine.push(middleware);
+            stubProviderRequests(provider, [stubBlockNumberRequest('0x100')]);
+
+            await engine.handle({
+              jsonrpc: '2.0',
+              id: 1,
+              method,
+              params: buildMockParamsWithoutBlockParamAt(blockParamIndex),
+            });
+
+            expect(middleware).toHaveBeenCalledWith(
+              expect.objectContaining({
+                params: buildMockParamsWithBlockParamAt(
+                  blockParamIndex,
+                  '0x100',
+                ),
+              }),
+              expect.anything(),
+              expect.anything(),
+              expect.anything(),
+            );
+          });
+        });
+
+        it.each(['earliest', 'pending', '0x200'])(
+          'does not touch the request params before proceeding to the next middleware if the block param is something other than "latest", like %o',
+          async (blockParam) => {
+            await withTestSetup(async ({ engine, provider, blockTracker }) => {
+              engine.push(createBlockRefMiddleware({ provider, blockTracker }));
+              const middleware = buildFinalMiddlewareWithDefaultResponse();
+              engine.push(middleware);
+              stubProviderRequests(provider, [stubBlockNumberRequest('0x100')]);
+
+              await engine.handle({
+                jsonrpc: '2.0',
+                id: 1,
+                method,
+                params: buildMockParamsWithBlockParamAt(
+                  blockParamIndex,
+                  blockParam,
+                ),
+              });
+
+              expect(middleware).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  params: buildMockParamsWithBlockParamAt(
+                    blockParamIndex,
+                    blockParam,
+                  ),
+                }),
+                expect.anything(),
+                expect.anything(),
+                expect.anything(),
+              );
+            });
+          },
+        );
+      });
+    });
+  });
+
+  describe('when the RPC method does not take a block parameter', () => {
+    it('does not touch the request params before proceeding to the next middleware', async () => {
+      await withTestSetup(async ({ engine, provider, blockTracker }) => {
+        engine.push(createBlockRefMiddleware({ provider, blockTracker }));
+        const middleware = buildFinalMiddlewareWithDefaultResponse();
+        engine.push(middleware);
+        stubProviderRequests(provider, [stubBlockNumberRequest('0x100')]);
+
+        await engine.handle({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'a_non_block_param_method',
+          params: ['some value', '0x200'],
+        });
+
+        expect(middleware).toHaveBeenCalledWith(
+          expect.objectContaining({
+            params: ['some value', '0x200'],
+          }),
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
+  });
+});
+
+/**
+ * Calls the given function, which should represent a test of some kind, with data
+ * that the test can use, namely, a JsonRpcEngine instance, a provider object,
+ * and a block tracker.
+ *
+ * @param fn - A function.
+ * @returns Whatever the function returns.
+ */
+async function withTestSetup<T>(fn: WithTestSetupCallback<T>) {
   const engine = new JsonRpcEngine();
   const provider = providerFromEngine(engine);
-
   const blockTracker = new PollingBlockTracker({
     provider: provider as Provider,
   });
 
-  return { engine, provider, blockTracker };
+  return await fn({ engine, provider, blockTracker });
 }
 
-describe('block ref', () => {
-  it('should rewrite "latest" blockRef to current block', async () => {
-    const { engine, provider, blockTracker } = createTestSetup();
-    const providerReqs: any[] = [];
-    const spy = jest
-      .spyOn(provider, 'sendAsync')
-      .mockImplementation((_req, cb) => {
-        providerReqs.push(_req);
-        cb(
-          undefined as any,
-          { id: _req.id, result: '0x0', jsonrpc: '2.0' } as any,
-        );
-      });
+/**
+ * Creates a middleware function that ends the request, but not before ensuring
+ * that the response has been filled with something.
+ *
+ * @returns The created middleware, as a mock function.
+ */
+function buildFinalMiddlewareWithDefaultResponse<T, U>(): JsonRpcMiddleware<
+  T,
+  U | 'default response'
+> {
+  return jest.fn((req, res, _next, end) => {
+    if (res.id === undefined) {
+      res.id = req.id;
+    }
 
-    engine.push(createBlockRefMiddleware({ blockTracker, provider }));
+    if (res.jsonrpc === undefined) {
+      res.jsonrpc = '2.0';
+    }
 
-    engine.push((_req, res, _next, end) => {
-      if (res.result) {
-        end();
-      } else {
-        _next();
-      }
-    });
+    if (res.result === undefined) {
+      res.result = 'default response';
+    }
 
-    await pify(engine.handle).call(engine, {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'eth_getBalance',
-      params: [testAddresses[0], 'latest'],
-    });
-
-    expect(providerReqs[1].params[1]).toStrictEqual('0x0');
-    expect(spy).toHaveBeenCalled();
+    end();
   });
-});
+}
+
+/**
+ * Some JSON-RPC endpoints take a "block" param (example: `eth_blockNumber`)
+ * which can optionally be left out. Additionally, the endpoint may support some
+ * number of arguments, although the "block" param will always be last, even if
+ * it is optional. Given this, this function builds a `params` array for such an
+ * endpoint with the given "block" param added at the end.
+ *
+ * @param index - The index within the `params` array to add the "block" param.
+ * @param blockParam - The desired "block" param to add.
+ * @returns The mock params.
+ */
+function buildMockParamsWithBlockParamAt(
+  blockParamIndex: number,
+  blockParam: string,
+): string[] {
+  const params = [];
+
+  for (let i = 0; i < blockParamIndex; i++) {
+    params.push('some value');
+  }
+
+  params.push(blockParam);
+  return params;
+}
+
+/**
+ * Some JSON-RPC endpoints take a "block" param (example: `eth_blockNumber`)
+ * which can optionally be left out. Additionally, the endpoint may support some
+ * number of arguments, although the "block" param will always be last, even if
+ * it is optional. Given this, this function builds a mock `params` array for
+ * such an endpoint, filling it with arbitrary values, but with the "block"
+ * param missing.
+ *
+ * @param {number} index - The index within the `params` array where the "block"
+ * param *would* appear.
+ * @returns {string[]} The mock params.
+ */
+function buildMockParamsWithoutBlockParamAt(blockParamIndex: number): string[] {
+  const params = [];
+
+  for (let i = 0; i < blockParamIndex; i++) {
+    params.push('some value');
+  }
+
+  return params;
+}
+
+/**
+ * Builds a canned response for a `eth_blockNumber` request made to
+ * `provider.sendAsync` such that the response will return the given block
+ * number. Intended to be used in conjunction with `stubProviderRequests`.
+ *
+ * @param blockNumber - The block number (default: '0x0').
+ * @returns The request/response pair.
+ */
+function stubBlockNumberRequest(
+  blockNumber = '0x0',
+): ProviderRequestStub<undefined[], string> {
+  return {
+    request: {
+      method: 'eth_blockNumber',
+      params: [],
+    },
+    response: (req) => ({
+      id: req.id,
+      jsonrpc: '2.0',
+      result: blockNumber,
+    }),
+  };
+}
+
+/**
+ * Provides a way to assign specific responses to specific requests that are
+ * made through a provider. When `provider.sendAsync` is called, a stub matching
+ * the request will be looked for; if one is found, it is used and then
+ * discarded, unless `remainAfterUse` is set for the stub.
+ *
+ * @param provider - The provider.
+ * @param stubs - A series of pairs, where each pair specifies a request object
+ * — or part of one, at least — and a response for that request. The response
+ * is actually a function that takes two arguments: the *real* request and the
+ * number of times that that request has been made (counting the first as 1).
+ * This latter argument be used to specify different responses for different
+ * instances of the same request. The function should return a response object.
+ * @returns The Jest spy object that represents `provider.sendAsync` (so that
+ * you can make assertions on the method later, if you like).
+ */
+function stubProviderRequests(
+  provider: SafeEventEmitterProvider,
+  stubs: ProviderRequestStub<any, any>[],
+) {
+  const remainingStubs = clone(stubs);
+  const callNumbersByRequest = new Map<
+    Partial<JsonRpcRequest<unknown>>,
+    number
+  >();
+  return jest.spyOn(provider, 'sendAsync').mockImplementation((request, cb) => {
+    const stubIndex = remainingStubs.findIndex((stub) =>
+      requestMatches(stub.request, request),
+    );
+
+    if (stubIndex === -1) {
+      throw new Error(`Unrecognized request ${JSON.stringify(request)}`);
+    } else {
+      const stub = remainingStubs[stubIndex];
+      const callNumber = callNumbersByRequest.get(stub.request) ?? 1;
+
+      cb(undefined, stub.response(request, callNumber));
+
+      callNumbersByRequest.set(stub.request, callNumber + 1);
+
+      if (!stub.remainAfterUse) {
+        remainingStubs.splice(stubIndex, 1);
+      }
+    }
+  });
+}
+
+/**
+ * When using `stubProviderRequests` to list canned responses for specific
+ * requests that are made to `provider.sendAsync`, you don't need to provide the
+ * full request object to go along with the response, but only part of that
+ * request object. When `provider.sendAsync` is then called, we can look up the
+ * compare the real request object to the request object that was specified to
+ * find a match. This function is used to do that comparison (and other
+ * like comparisons).
+ *
+ * @param requestMatcher - A partial request object.
+ * @param request - A real request object.
+ * @returns True or false depending on whether the partial request object "fits
+ * inside" the real request object.
+ */
+function requestMatches(
+  requestMatcher: Partial<JsonRpcRequest<unknown>>,
+  request: JsonRpcRequest<unknown>,
+): boolean {
+  return (Object.keys(requestMatcher) as (keyof typeof requestMatcher)[]).every(
+    (key) => isDeepStrictEqual(requestMatcher[key], request[key]),
+  );
+}

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -48,16 +48,16 @@ export function createBlockRefMiddleware({
     }
 
     // lookup latest block
-    const latestBlock = await blockTracker.getLatestBlock();
+    const latestBlockNumber = await blockTracker.getLatestBlock();
     log(
-      `blockRef is "latest", setting param ${blockRefIndex} to latest block ${latestBlock}`,
+      `blockRef is "latest", setting param ${blockRefIndex} to latest block ${latestBlockNumber}`,
     );
 
     // create child request with specific block-ref
     const childRequest = clone(req);
 
     if (childRequest.params) {
-      childRequest.params[blockRefIndex] = latestBlock;
+      childRequest.params[blockRefIndex] = latestBlockNumber;
     }
 
     // perform child request
@@ -65,7 +65,6 @@ export function createBlockRefMiddleware({
     const childRes: PendingJsonRpcResponse<Block> = await pify(
       (provider as SafeEventEmitterProvider).sendAsync,
     ).call(provider, childRequest);
-
     // copy child response onto original response
     res.result = childRes.result;
     res.error = childRes.error;

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -1,11 +1,5 @@
 import { PollingBlockTracker } from 'eth-block-tracker';
-import {
-  createAsyncMiddleware,
-  JsonRpcMiddleware,
-  PendingJsonRpcResponse,
-} from 'json-rpc-engine';
-import clone from 'clone';
-import pify from 'pify';
+import { createAsyncMiddleware, JsonRpcMiddleware } from 'json-rpc-engine';
 import { projectLogger, createModuleLogger } from './logging-utils';
 import { blockTagParamIndex } from './utils/cache';
 import type { Block, SafeEventEmitterProvider } from './types';
@@ -31,38 +25,31 @@ export function createBlockRefMiddleware({
     );
   }
 
-  return createAsyncMiddleware(async (req, res, next) => {
-    const blockRefIndex: number | undefined = blockTagParamIndex(req);
-    // skip if method does not include blockRef
+  return createAsyncMiddleware(async (req, _res, next) => {
+    const blockRefIndex = blockTagParamIndex(req);
+
     if (blockRefIndex === undefined) {
       return next();
     }
-    // skip if not "latest"
-    let blockRef: string | undefined = req.params?.[blockRefIndex];
-    // omitted blockRef implies "latest"
-    if (blockRef === undefined) {
-      blockRef = 'latest';
-    }
+
+    const blockRef = req.params?.[blockRefIndex] ?? 'latest';
 
     if (blockRef !== 'latest') {
       log('blockRef is not "latest", carrying request forward');
       return next();
     }
-    // lookup latest block
-    const latestBlockNumber = await blockTracker.getLatestBlock();
-    // create child request with specific block-ref
-    const childRequest = clone(req);
-    if (childRequest.params) {
-      childRequest.params[blockRefIndex] = latestBlockNumber;
+
+    const latestBlock = await blockTracker.getLatestBlock();
+    log(
+      `blockRef is "latest", setting param ${blockRefIndex} to latest block ${latestBlock}`,
+    );
+
+    if (req.params === undefined) {
+      req.params = [];
     }
-    // perform child request
-    log('Performing another request %o', childRequest);
-    const childRes: PendingJsonRpcResponse<Block> = await pify(
-      (provider as SafeEventEmitterProvider).sendAsync,
-    ).call(provider, childRequest);
-    // copy child response onto original response
-    res.result = childRes.result;
-    res.error = childRes.error;
+
+    req.params[blockRefIndex] = latestBlock;
+
     return next();
   });
 }


### PR DESCRIPTION
The goal of the `block-ref` middleware is to look for instances in request parameters where "latest" is being used as a block parameter and replace it with the actual latest block number (as reported by the block tracker). The middleware will then make a child request through the provider using the resolved parameters and copy the child response onto the final response object.

That is fine; however, this middleware then calls the next middleware in the stack, which in practice will make another request, and that will end up overwriting the child response set in this middleware. That makes this middleware ineffective.

So, this commit removes the `next()` call from the `block-ref` middleware so that when it takes effect it stops the chain and prevents an extra request.

In addition, this fills in missing tests for the middleware by reusing some test helpers from a previous PR.

---

Fixes #142.