### PR TITLE
Update new tests to destroy block tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@metamask/utils": "^3.0.3",
     "btoa": "^1.2.1",
     "clone": "^2.1.1",
-    "eth-block-tracker": "^5.0.1",
+    "eth-block-tracker": "^6.0.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "json-stable-stringify": "^1.0.1",

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -472,8 +472,12 @@ async function withTestSetup<T>(
     engine.push(middleware);
   }
 
-  if (callback === undefined) {
-    return undefined;
+  try {
+    if (callback === undefined) {
+      return undefined;
+    }
+    return await callback({ engine, provider, blockTracker });
+  } finally {
+    await blockTracker.destroy();
   }
-  return await callback({ engine, provider, blockTracker });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,7 +866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^3.0.3":
+"@metamask/utils@npm:^3.0.1, @metamask/utils@npm:^3.0.3":
   version: 3.0.3
   resolution: "@metamask/utils@npm:3.0.3"
   dependencies:
@@ -2766,14 +2766,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eth-block-tracker@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "eth-block-tracker@npm:5.0.1"
+"eth-block-tracker@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "eth-block-tracker@npm:6.0.0"
   dependencies:
     "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/utils": ^3.0.1
     json-rpc-random-id: ^1.0.1
     pify: ^3.0.0
-  checksum: 83b2dd28fb7f12d644f1c1bc72011fb6bb683012489973e31171d445a34ddf6a1c167be4e4232bf7eb65144f08d92705795cf6b371c5aa6a8e78ebf48e4d5654
+  checksum: ad1199b822a9a3ff2673ecc92ca7cda0a37828e5bfd1927fd917a8085a99904fc29d3ef2392068bcfb14e47589df097940ef28f3e9025d1681e56a89b07e284e
   languageName: node
   linkType: hard
 
@@ -2807,7 +2808,7 @@ __metadata:
     eslint-plugin-jest: ^24.1.3
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.3.1
-    eth-block-tracker: ^5.0.1
+    eth-block-tracker: ^6.0.0
     eth-rpc-errors: ^4.0.3
     jest: ^27.5.1
     json-rpc-engine: ^6.1.0


### PR DESCRIPTION
Certain middleware use a polling block tracker to retrieve the latest block. This type of block tracker has the ability to make a quick request in addition to polling, but doing so requires starting the poll loop and then immediately stopping it. This means that it is possible for the block tracker to be in a running state when a test that uses it ends. To avoid this, we need to make sure we completely shut down the block tracker at the end of each test. The ability to do this was added in a recent version of `eth-block-tracker`.