### PR TITLE
Refactor cache helper methods

### DIFF
--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -4,7 +4,7 @@ import { projectLogger, createModuleLogger } from './logging-utils';
 import {
   cacheIdentifierForPayload,
   blockTagForPayload,
-  cacheTypeForPayload,
+  cacheTypeForMethod,
   canCache,
 } from './utils/cache';
 import type {
@@ -162,7 +162,7 @@ export function createBlockCacheMiddleware({
       return next();
     }
     // check type and matching strategy
-    const type: string = cacheTypeForPayload(req);
+    const type: string = cacheTypeForMethod(req.method);
     const strategy: BlockCacheStrategy = strategies[type];
     // If there's no strategy in place, pass it down the chain.
     if (!strategy) {

--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -88,7 +88,7 @@ class BlockCacheStrategy {
 
   canCacheRequest(payload: Payload): boolean {
     // check request method
-    if (!canCache(payload)) {
+    if (!canCache(payload.method)) {
       return false;
     }
     // check blockTag

--- a/src/block-ref-rewrite.ts
+++ b/src/block-ref-rewrite.ts
@@ -17,7 +17,7 @@ export function createBlockRefRewriteMiddleware({
   }
 
   return createAsyncMiddleware(async (req, _res, next) => {
-    const blockRefIndex: number | undefined = blockTagParamIndex(req);
+    const blockRefIndex: number | undefined = blockTagParamIndex(req.method);
     // skip if method does not include blockRef
     if (blockRefIndex === undefined) {
       return next();

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -32,7 +32,7 @@ export function createBlockRefMiddleware({
   }
 
   return createAsyncMiddleware(async (req, res, next) => {
-    const blockRefIndex = blockTagParamIndex(req);
+    const blockRefIndex = blockTagParamIndex(req.method);
 
     // skip if method does not include blockRef
     if (blockRefIndex === undefined) {

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -48,7 +48,7 @@ export function createRetryOnEmptyMiddleware({
   }
 
   return createAsyncMiddleware(async (req, res, next) => {
-    const blockRefIndex: number | undefined = blockTagParamIndex(req);
+    const blockRefIndex: number | undefined = blockTagParamIndex(req.method);
     // skip if method does not include blockRef
     if (blockRefIndex === undefined) {
       return next();

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,0 +1,145 @@
+import { blockTagParamIndex, cacheTypeForMethod } from './cache';
+
+const knownMethods = [
+  'web3_clientVersion',
+  'web3_sha3',
+  'eth_protocolVersion',
+  'eth_getBlockTransactionCountByHash',
+  'eth_getUncleCountByBlockHash',
+  'eth_getCode',
+  'eth_getBlockByHash',
+  'eth_getTransactionByHash',
+  'eth_getTransactionByBlockHashAndIndex',
+  'eth_getTransactionReceipt',
+  'eth_getUncleByBlockHashAndIndex',
+  'eth_getCompilers',
+  'eth_compileLLL',
+  'eth_compileSolidity',
+  'eth_compileSerpent',
+  'shh_version',
+  'test_permaCache',
+  'eth_getBlockByNumber',
+  'eth_getBlockTransactionCountByNumber',
+  'eth_getUncleCountByBlockNumber',
+  'eth_getTransactionByBlockNumberAndIndex',
+  'eth_getUncleByBlockNumberAndIndex',
+  'test_forkCache',
+  'eth_gasPrice',
+  'eth_blockNumber',
+  'eth_getBalance',
+  'eth_getStorageAt',
+  'eth_getTransactionCount',
+  'eth_call',
+  'eth_estimateGas',
+  'eth_getFilterLogs',
+  'eth_getLogs',
+  'test_blockCache',
+];
+
+describe('cache utils', () => {
+  describe('blockTagParamIndex', () => {
+    it(`should return expected block index for each known method`, () => {
+      const blockTagIndexes = knownMethods.reduce((indexes, method) => {
+        indexes[method] = blockTagParamIndex(method);
+        return indexes;
+      }, {} as Record<string, number | undefined>);
+
+      expect(blockTagIndexes).toMatchInlineSnapshot(`
+        Object {
+          "eth_blockNumber": undefined,
+          "eth_call": 1,
+          "eth_compileLLL": undefined,
+          "eth_compileSerpent": undefined,
+          "eth_compileSolidity": undefined,
+          "eth_estimateGas": undefined,
+          "eth_gasPrice": undefined,
+          "eth_getBalance": 1,
+          "eth_getBlockByHash": undefined,
+          "eth_getBlockByNumber": 0,
+          "eth_getBlockTransactionCountByHash": undefined,
+          "eth_getBlockTransactionCountByNumber": undefined,
+          "eth_getCode": 1,
+          "eth_getCompilers": undefined,
+          "eth_getFilterLogs": undefined,
+          "eth_getLogs": undefined,
+          "eth_getStorageAt": 2,
+          "eth_getTransactionByBlockHashAndIndex": undefined,
+          "eth_getTransactionByBlockNumberAndIndex": undefined,
+          "eth_getTransactionByHash": undefined,
+          "eth_getTransactionCount": 1,
+          "eth_getTransactionReceipt": undefined,
+          "eth_getUncleByBlockHashAndIndex": undefined,
+          "eth_getUncleByBlockNumberAndIndex": undefined,
+          "eth_getUncleCountByBlockHash": undefined,
+          "eth_getUncleCountByBlockNumber": undefined,
+          "eth_protocolVersion": undefined,
+          "shh_version": undefined,
+          "test_blockCache": undefined,
+          "test_forkCache": undefined,
+          "test_permaCache": undefined,
+          "web3_clientVersion": undefined,
+          "web3_sha3": undefined,
+        }
+      `);
+    });
+
+    it('should return "undefined" for an unrecognized method', () => {
+      const index = blockTagParamIndex('this_method_does_not_exist');
+
+      expect(index).toBeUndefined();
+    });
+  });
+
+  describe('cacheTypeForMethod', () => {
+    it(`should return expected cache type for each known method`, () => {
+      const cacheTypes = knownMethods.reduce((types, method) => {
+        types[method] = cacheTypeForMethod(method);
+        return types;
+      }, {} as Record<string, string>);
+
+      expect(cacheTypes).toMatchInlineSnapshot(`
+        Object {
+          "eth_blockNumber": "block",
+          "eth_call": "block",
+          "eth_compileLLL": "perma",
+          "eth_compileSerpent": "perma",
+          "eth_compileSolidity": "perma",
+          "eth_estimateGas": "block",
+          "eth_gasPrice": "block",
+          "eth_getBalance": "block",
+          "eth_getBlockByHash": "perma",
+          "eth_getBlockByNumber": "fork",
+          "eth_getBlockTransactionCountByHash": "perma",
+          "eth_getBlockTransactionCountByNumber": "fork",
+          "eth_getCode": "perma",
+          "eth_getCompilers": "perma",
+          "eth_getFilterLogs": "block",
+          "eth_getLogs": "block",
+          "eth_getStorageAt": "block",
+          "eth_getTransactionByBlockHashAndIndex": "perma",
+          "eth_getTransactionByBlockNumberAndIndex": "fork",
+          "eth_getTransactionByHash": "perma",
+          "eth_getTransactionCount": "block",
+          "eth_getTransactionReceipt": "perma",
+          "eth_getUncleByBlockHashAndIndex": "perma",
+          "eth_getUncleByBlockNumberAndIndex": "fork",
+          "eth_getUncleCountByBlockHash": "perma",
+          "eth_getUncleCountByBlockNumber": "fork",
+          "eth_protocolVersion": "perma",
+          "shh_version": "perma",
+          "test_blockCache": "block",
+          "test_forkCache": "fork",
+          "test_permaCache": "perma",
+          "web3_clientVersion": "perma",
+          "web3_sha3": "perma",
+        }
+      `);
+    });
+
+    it('should return "never" for an unrecognized method', () => {
+      const index = cacheTypeForMethod('this_method_does_not_exist');
+
+      expect(index).toBe('never');
+    });
+  });
+});

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,4 +1,4 @@
-import { blockTagParamIndex, cacheTypeForMethod } from './cache';
+import { blockTagParamIndex, cacheTypeForMethod, canCache } from './cache';
 
 const knownMethods = [
   'web3_clientVersion',
@@ -37,6 +37,18 @@ const knownMethods = [
 ];
 
 describe('cache utils', () => {
+  describe('canCache', () => {
+    for (const method of knownMethods) {
+      it(`should be able to cache '${method}'`, () => {
+        expect(canCache(method)).toBe(true);
+      });
+    }
+
+    it('should not be able to cache an unknown method', () => {
+      expect(canCache('this_method_does_not_exist')).toBe(false);
+    });
+  });
+
   describe('blockTagParamIndex', () => {
     it(`should return expected block index for each known method`, () => {
       const blockTagIndexes = knownMethods.reduce((indexes, method) => {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -50,6 +50,13 @@ export function paramsWithoutBlockTag(payload: Payload): string[] {
   return payload.params.slice(0, index);
 }
 
+/**
+ * Returns the index of the block parameter for the given method.
+ *
+ * @param method - A JSON-RPC method.
+ * @returns The index of the block parameter for that method, or `undefined` if
+ * there is no known block parameter.
+ */
 export function blockTagParamIndex(method?: string): number | undefined {
   switch (method) {
     // blockTag is at index 2
@@ -70,6 +77,12 @@ export function blockTagParamIndex(method?: string): number | undefined {
   }
 }
 
+/**
+ * Return the cache type used for the given method.
+ *
+ * @param method - A JSON-RPC method.
+ * @returns The cache type to use for that method.
+ */
 export function cacheTypeForMethod(method?: string): string {
   switch (method) {
     // cache permanently

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -15,14 +15,14 @@ export function cacheIdentifierForPayload(
 }
 
 export function canCache(payload: Payload): boolean {
-  return cacheTypeForPayload(payload) !== 'never';
+  return cacheTypeForMethod(payload.method) !== 'never';
 }
 
 export function blockTagForPayload(payload: Payload): string | undefined {
   if (!payload.params) {
     return undefined;
   }
-  const index: number | undefined = blockTagParamIndex(payload);
+  const index: number | undefined = blockTagParamIndex(payload.method);
 
   // Block tag param not passed.
   if (index === undefined || index >= payload.params.length) {
@@ -36,7 +36,7 @@ export function paramsWithoutBlockTag(payload: Payload): string[] {
   if (!payload.params) {
     return [];
   }
-  const index: number | undefined = blockTagParamIndex(payload);
+  const index: number | undefined = blockTagParamIndex(payload.method);
 
   // Block tag param not passed.
   if (index === undefined || index >= payload.params.length) {
@@ -50,8 +50,8 @@ export function paramsWithoutBlockTag(payload: Payload): string[] {
   return payload.params.slice(0, index);
 }
 
-export function blockTagParamIndex(payload: Payload): number | undefined {
-  switch (payload.method) {
+export function blockTagParamIndex(method?: string): number | undefined {
+  switch (method) {
     // blockTag is at index 2
     case 'eth_getStorageAt':
       return 2;
@@ -70,8 +70,8 @@ export function blockTagParamIndex(payload: Payload): number | undefined {
   }
 }
 
-export function cacheTypeForPayload(payload: Payload): string {
-  switch (payload.method) {
+export function cacheTypeForMethod(method?: string): string {
+  switch (method) {
     // cache permanently
     case 'web3_clientVersion':
     case 'web3_sha3':

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -8,14 +8,20 @@ export function cacheIdentifierForPayload(
   const simpleParams: string[] = skipBlockRef
     ? paramsWithoutBlockTag(payload)
     : payload.params ?? [];
-  if (canCache(payload)) {
+  if (canCache(payload.method)) {
     return `${payload.method}:${stringify(simpleParams)}`;
   }
   return null;
 }
 
-export function canCache(payload: Payload): boolean {
-  return cacheTypeForMethod(payload.method) !== 'never';
+/**
+ * Return whether a method can be cached or not.
+ *
+ * @param method - The method to check.
+ * @returns Whether the method can be cached.
+ */
+export function canCache(method?: string): boolean {
+  return cacheTypeForMethod(method) !== 'never';
 }
 
 export function blockTagForPayload(payload: Payload): string | undefined {


### PR DESCRIPTION
Refactor cache helper methods to no longer use the `Payload` type to access the request method. Instead they now take the method directly.

This relates to #176, in that it reduces the number of places where we are using this `Payload` type that we need to eliminate for #176.