### PR TITLE
Rename the package to be under the `@metamask` scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eth-json-rpc-middleware",
+  "name": "@metamask/eth-json-rpc-middleware",
   "version": "9.0.1",
   "description": "Ethereum-related json-rpc-engine middleware.",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -845,6 +845,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-middleware@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@metamask/eth-json-rpc-middleware@workspace:."
+  dependencies:
+    "@jest/globals": ^27.5.1
+    "@lavamoat/allow-scripts": ^2.0.3
+    "@metamask/auto-changelog": ^3.1.0
+    "@metamask/eslint-config": ^8.0.0
+    "@metamask/eslint-config-jest": ^8.0.0
+    "@metamask/eslint-config-nodejs": ^8.0.0
+    "@metamask/eslint-config-typescript": ^8.0.0
+    "@metamask/eth-sig-util": ^5.0.0
+    "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/utils": ^3.0.3
+    "@types/btoa": ^1.2.3
+    "@types/clone": ^2.1.0
+    "@types/jest": ^27.4.1
+    "@types/json-stable-stringify": ^1.0.32
+    "@types/node": ^17.0.23
+    "@types/pify": ^3.0.2
+    "@typescript-eslint/eslint-plugin": ^4.21.0
+    "@typescript-eslint/parser": ^4.21.0
+    btoa: ^1.2.1
+    clone: ^2.1.1
+    eslint: ^7.14.0
+    eslint-config-prettier: ^8.1.0
+    eslint-plugin-import: ^2.22.1
+    eslint-plugin-jest: ^24.1.3
+    eslint-plugin-node: ^11.1.0
+    eslint-plugin-prettier: ^3.3.1
+    eth-block-tracker: ^5.0.1
+    eth-rpc-errors: ^4.0.3
+    jest: ^27.5.1
+    json-rpc-engine: ^6.1.0
+    json-stable-stringify: ^1.0.1
+    node-fetch: ^2.6.7
+    pify: ^3.0.0
+    prettier: ^2.2.1
+    prettier-plugin-packagejson: ^2.2.11
+    rimraf: ^3.0.2
+    ts-jest: ^27.1.4
+    ts-node: ^10.7.0
+    typescript: ~4.2.4
+  languageName: unknown
+  linkType: soft
+
 "@metamask/eth-sig-util@npm:^5.0.0":
   version: 5.0.2
   resolution: "@metamask/eth-sig-util@npm:5.0.2"
@@ -2776,52 +2822,6 @@ __metadata:
   checksum: 83b2dd28fb7f12d644f1c1bc72011fb6bb683012489973e31171d445a34ddf6a1c167be4e4232bf7eb65144f08d92705795cf6b371c5aa6a8e78ebf48e4d5654
   languageName: node
   linkType: hard
-
-"eth-json-rpc-middleware@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "eth-json-rpc-middleware@workspace:."
-  dependencies:
-    "@jest/globals": ^27.5.1
-    "@lavamoat/allow-scripts": ^2.0.3
-    "@metamask/auto-changelog": ^3.1.0
-    "@metamask/eslint-config": ^8.0.0
-    "@metamask/eslint-config-jest": ^8.0.0
-    "@metamask/eslint-config-nodejs": ^8.0.0
-    "@metamask/eslint-config-typescript": ^8.0.0
-    "@metamask/eth-sig-util": ^5.0.0
-    "@metamask/safe-event-emitter": ^2.0.0
-    "@metamask/utils": ^3.0.3
-    "@types/btoa": ^1.2.3
-    "@types/clone": ^2.1.0
-    "@types/jest": ^27.4.1
-    "@types/json-stable-stringify": ^1.0.32
-    "@types/node": ^17.0.23
-    "@types/pify": ^3.0.2
-    "@typescript-eslint/eslint-plugin": ^4.21.0
-    "@typescript-eslint/parser": ^4.21.0
-    btoa: ^1.2.1
-    clone: ^2.1.1
-    eslint: ^7.14.0
-    eslint-config-prettier: ^8.1.0
-    eslint-plugin-import: ^2.22.1
-    eslint-plugin-jest: ^24.1.3
-    eslint-plugin-node: ^11.1.0
-    eslint-plugin-prettier: ^3.3.1
-    eth-block-tracker: ^5.0.1
-    eth-rpc-errors: ^4.0.3
-    jest: ^27.5.1
-    json-rpc-engine: ^6.1.0
-    json-stable-stringify: ^1.0.1
-    node-fetch: ^2.6.7
-    pify: ^3.0.0
-    prettier: ^2.2.1
-    prettier-plugin-packagejson: ^2.2.11
-    rimraf: ^3.0.2
-    ts-jest: ^27.1.4
-    ts-node: ^10.7.0
-    typescript: ~4.2.4
-  languageName: unknown
-  linkType: soft
 
 "eth-rpc-errors@npm:^4.0.2, eth-rpc-errors@npm:^4.0.3":
   version: 4.0.3


### PR DESCRIPTION
The package has been renamed from `eth-json-rpc-middleware` to `@metamask/eth-json-rpc-middleware`.