### PR TITLE
Rename `blockTagForPayload` to `blockTagForRequest`

### DIFF
--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -94,7 +94,7 @@ class BlockCacheStrategy {
       return false;
     }
     // check blockTag
-    const blockTag: string | undefined = blockTagForRequest(request);
+    const blockTag = blockTagForRequest(request);
 
     if (blockTag === 'pending') {
       return false;
@@ -179,10 +179,11 @@ export function createBlockCacheMiddleware({
       }
 
       // get block reference (number or keyword)
-      let blockTag: string | undefined = blockTagForRequest(req);
-      if (!blockTag) {
-        blockTag = 'latest';
-      }
+      const requestBlockTag = blockTagForRequest(req);
+      const blockTag =
+        requestBlockTag && typeof requestBlockTag === 'string'
+          ? requestBlockTag
+          : 'latest';
 
       log('blockTag = %o, req = %o', blockTag, req);
 

--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -1,9 +1,9 @@
 import { PollingBlockTracker } from 'eth-block-tracker';
-import { createAsyncMiddleware } from 'json-rpc-engine';
+import { createAsyncMiddleware, JsonRpcRequest } from 'json-rpc-engine';
 import { projectLogger, createModuleLogger } from './logging-utils';
 import {
   cacheIdentifierForPayload,
-  blockTagForPayload,
+  blockTagForRequest,
   cacheTypeForMethod,
   canCache,
   CacheStrategy,
@@ -88,13 +88,13 @@ class BlockCacheStrategy {
     blockCache[identifier] = result;
   }
 
-  canCacheRequest(payload: Payload): boolean {
+  canCacheRequest(request: JsonRpcRequest<unknown>): boolean {
     // check request method
-    if (!canCache(payload.method)) {
+    if (!canCache(request.method)) {
       return false;
     }
     // check blockTag
-    const blockTag: string | undefined = blockTagForPayload(payload);
+    const blockTag: string | undefined = blockTagForRequest(request);
 
     if (blockTag === 'pending') {
       return false;
@@ -179,7 +179,7 @@ export function createBlockCacheMiddleware({
       }
 
       // get block reference (number or keyword)
-      let blockTag: string | undefined = blockTagForPayload(req);
+      let blockTag: string | undefined = blockTagForRequest(req);
       if (!blockTag) {
         blockTag = 'latest';
       }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -53,9 +53,7 @@ export function canCache(method?: string): boolean {
  * @param request - The JSON-RPC request.
  * @returns The block parameter in the given request, or `undefined` if none was found.
  */
-export function blockTagForRequest(
-  request: JsonRpcRequest<unknown>,
-): string | undefined {
+export function blockTagForRequest(request: JsonRpcRequest<unknown>): unknown {
   if (!request.params) {
     return undefined;
   }

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,4 +1,5 @@
 import stringify from 'json-stable-stringify';
+import { JsonRpcRequest } from 'json-rpc-engine';
 import type { Payload } from '../types';
 
 /**
@@ -46,18 +47,30 @@ export function canCache(method?: string): boolean {
   return cacheTypeForMethod(method) !== CacheStrategy.Never;
 }
 
-export function blockTagForPayload(payload: Payload): string | undefined {
-  if (!payload.params) {
+/**
+ * Return the block parameter for the given request, if it has one.
+ *
+ * @param request - The JSON-RPC request.
+ * @returns The block parameter in the given request, or `undefined` if none was found.
+ */
+export function blockTagForRequest(
+  request: JsonRpcRequest<unknown>,
+): string | undefined {
+  if (!request.params) {
     return undefined;
   }
-  const index: number | undefined = blockTagParamIndex(payload.method);
+  const index: number | undefined = blockTagParamIndex(request.method);
 
   // Block tag param not passed.
-  if (index === undefined || index >= payload.params.length) {
+  if (
+    index === undefined ||
+    !Array.isArray(request.params) ||
+    index >= request.params.length
+  ) {
     return undefined;
   }
 
-  return payload.params[index];
+  return request.params[index];
 }
 
 export function paramsWithoutBlockTag(payload: Payload): string[] {


### PR DESCRIPTION
The utility method `blockTagForPayload` has been renamed to `blockTagForRequest`, and updated to accept a JSON-RPC request rather than a `Payload`. Documentation and tests have been added as well.

Relates to #176, which is partially caused by this `Payload` type that we're removing one usage of here.