### PR TITLE
Use unknown JSON-RPC requests and responses

### DIFF
--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -132,7 +132,7 @@ class BlockCacheStrategy {
 
 export function createBlockCacheMiddleware({
   blockTracker,
-}: BlockCacheMiddlewareOptions = {}): JsonRpcCacheMiddleware<string[], Block> {
+}: BlockCacheMiddlewareOptions = {}): JsonRpcCacheMiddleware<unknown, unknown> {
   // validate options
   if (!blockTracker) {
     throw new Error(
@@ -150,7 +150,7 @@ export function createBlockCacheMiddleware({
   };
 
   return createAsyncMiddleware(
-    async (req: JsonRpcRequestToCache<string[]>, res, next) => {
+    async (req: JsonRpcRequestToCache<unknown>, res, next) => {
       // allow cach to be skipped if so specified
       if (req.skipCache) {
         return next();

--- a/src/block-ref-rewrite.ts
+++ b/src/block-ref-rewrite.ts
@@ -1,7 +1,6 @@
 import { PollingBlockTracker } from 'eth-block-tracker';
 import { createAsyncMiddleware, JsonRpcMiddleware } from 'json-rpc-engine';
 import { blockTagParamIndex } from './utils/cache';
-import type { Block } from './types';
 
 interface BlockRefRewriteMiddlewareOptions {
   blockTracker?: PollingBlockTracker;
@@ -9,7 +8,7 @@ interface BlockRefRewriteMiddlewareOptions {
 
 export function createBlockRefRewriteMiddleware({
   blockTracker,
-}: BlockRefRewriteMiddlewareOptions = {}): JsonRpcMiddleware<string[], Block> {
+}: BlockRefRewriteMiddlewareOptions = {}): JsonRpcMiddleware<unknown, unknown> {
   if (!blockTracker) {
     throw Error(
       'BlockRefRewriteMiddleware - mandatory "blockTracker" option is missing.',
@@ -23,7 +22,9 @@ export function createBlockRefRewriteMiddleware({
       return next();
     }
     // skip if not "latest"
-    let blockRef: string | undefined = req.params?.[blockRefIndex];
+    let blockRef: string | undefined = Array.isArray(req.params)
+      ? req.params[blockRefIndex]
+      : undefined;
     // omitted blockRef implies "latest"
     if (blockRef === undefined) {
       blockRef = 'latest';
@@ -34,7 +35,7 @@ export function createBlockRefRewriteMiddleware({
     }
     // rewrite blockRef to block-tracker's block number
     const latestBlockNumber = await blockTracker.getLatestBlock();
-    if (req.params) {
+    if (req.params && Array.isArray(req.params)) {
       // eslint-disable-next-line require-atomic-updates
       req.params[blockRefIndex] = latestBlockNumber;
     }

--- a/src/block-ref-rewrite.ts
+++ b/src/block-ref-rewrite.ts
@@ -35,7 +35,7 @@ export function createBlockRefRewriteMiddleware({
     }
     // rewrite blockRef to block-tracker's block number
     const latestBlockNumber = await blockTracker.getLatestBlock();
-    if (req.params && Array.isArray(req.params)) {
+    if (Array.isArray(req.params)) {
       // eslint-disable-next-line require-atomic-updates
       req.params[blockRefIndex] = latestBlockNumber;
     }

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -58,7 +58,7 @@ export function createBlockRefMiddleware({
     // create child request with specific block-ref
     const childRequest = clone(req);
 
-    if (childRequest.params && Array.isArray(childRequest.params)) {
+    if (Array.isArray(childRequest.params)) {
       childRequest.params[blockRefIndex] = latestBlockNumber;
     }
 

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -20,7 +20,7 @@ const log = createModuleLogger(projectLogger, 'block-ref');
 export function createBlockRefMiddleware({
   provider,
   blockTracker,
-}: BlockRefMiddlewareOptions = {}): JsonRpcMiddleware<string[], Block> {
+}: BlockRefMiddlewareOptions = {}): JsonRpcMiddleware<unknown, unknown> {
   if (!provider) {
     throw Error('BlockRefMiddleware - mandatory "provider" option is missing.');
   }
@@ -39,7 +39,9 @@ export function createBlockRefMiddleware({
       return next();
     }
 
-    const blockRef = req.params?.[blockRefIndex] ?? 'latest';
+    const blockRef = Array.isArray(req.params)
+      ? req.params[blockRefIndex] ?? 'latest'
+      : 'latest';
 
     // skip if not "latest"
     if (blockRef !== 'latest') {
@@ -56,7 +58,7 @@ export function createBlockRefMiddleware({
     // create child request with specific block-ref
     const childRequest = clone(req);
 
-    if (childRequest.params) {
+    if (childRequest.params && Array.isArray(childRequest.params)) {
       childRequest.params[blockRefIndex] = latestBlockNumber;
     }
 

--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -16,10 +16,22 @@ interface BlockTrackerInspectorMiddlewareOptions {
   blockTracker: PollingBlockTracker;
 }
 
-function hasProperty<Property extends string>(
+/**
+ * Any type that can be used as the name of an object property.
+ */
+type ValidPropertyType = string | number | symbol;
+
+/**
+ * Determines whether the given object has the given property.
+ *
+ * @param object - The object to check.
+ * @param property - The property to look for.
+ * @returns - Whether the object has the property.
+ */
+function hasProperty<Property extends ValidPropertyType>(
   object: unknown,
   property: Property,
-): object is Record<Property, unknown> {
+): object is Record<Property | ValidPropertyType, unknown> {
   return Object.hasOwnProperty.call(object, property);
 }
 

--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -47,7 +47,7 @@ function getResultBlockNumber(
     return undefined;
   }
 
-  if (result.blockNumber && typeof result.blockNumber === 'string') {
+  if (typeof result.blockNumber === 'string') {
     return result.blockNumber;
   }
   return undefined;

--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -1,7 +1,10 @@
 import { PollingBlockTracker } from 'eth-block-tracker';
-import { createAsyncMiddleware, JsonRpcMiddleware } from 'json-rpc-engine';
+import {
+  createAsyncMiddleware,
+  JsonRpcMiddleware,
+  PendingJsonRpcResponse,
+} from 'json-rpc-engine';
 import { projectLogger, createModuleLogger } from './logging-utils';
-import type { Block } from './types';
 
 const log = createModuleLogger(projectLogger, 'block-tracker-inspector');
 const futureBlockRefRequests: string[] = [
@@ -13,10 +16,38 @@ interface BlockTrackerInspectorMiddlewareOptions {
   blockTracker: PollingBlockTracker;
 }
 
+function hasProperty<Property extends string>(
+  object: unknown,
+  property: Property,
+): object is Record<Property, unknown> {
+  return Object.hasOwnProperty.call(object, property);
+}
+
+function getResultBlockNumber(
+  response: PendingJsonRpcResponse<unknown>,
+): string | undefined {
+  const { result } = response;
+  if (
+    !result ||
+    typeof result !== 'object' ||
+    !hasProperty(result, 'blockNumber')
+  ) {
+    return undefined;
+  }
+
+  if (result.blockNumber && typeof result.blockNumber === 'string') {
+    return result.blockNumber;
+  }
+  return undefined;
+}
+
 // inspect if response contains a block ref higher than our latest block
 export function createBlockTrackerInspectorMiddleware({
   blockTracker,
-}: BlockTrackerInspectorMiddlewareOptions): JsonRpcMiddleware<string[], Block> {
+}: BlockTrackerInspectorMiddlewareOptions): JsonRpcMiddleware<
+  unknown,
+  unknown
+> {
   return createAsyncMiddleware(async (req, res, next) => {
     if (!futureBlockRefRequests.includes(req.method)) {
       return next();
@@ -24,26 +55,25 @@ export function createBlockTrackerInspectorMiddleware({
     // eslint-disable-next-line node/callback-return
     await next();
     // abort if no result or no block number
-    if (!res.result?.blockNumber) {
+    const responseBlockNumber = getResultBlockNumber(res);
+    if (!responseBlockNumber) {
       return undefined;
     }
 
     log('res.result.blockNumber exists, proceeding. res = %o', res);
 
-    if (typeof res.result.blockNumber === 'string') {
-      // if number is higher, suggest block-tracker check for a new block
-      const blockNumber: number = Number.parseInt(res.result.blockNumber, 16);
-      // Typecast: If getCurrentBlock returns null, currentBlockNumber will be NaN, which is fine.
-      const currentBlockNumber: number = Number.parseInt(
-        blockTracker.getCurrentBlock() as any,
-        16,
+    // if number is higher, suggest block-tracker check for a new block
+    const blockNumber: number = Number.parseInt(responseBlockNumber, 16);
+    // Typecast: If getCurrentBlock returns null, currentBlockNumber will be NaN, which is fine.
+    const currentBlockNumber: number = Number.parseInt(
+      blockTracker.getCurrentBlock() as any,
+      16,
+    );
+    if (blockNumber > currentBlockNumber) {
+      log(
+        'blockNumber from response is greater than current block number, refreshing current block number',
       );
-      if (blockNumber > currentBlockNumber) {
-        log(
-          'blockNumber from response is greater than current block number, refreshing current block number',
-        );
-        await blockTracker.checkForLatestBlock();
-      }
+      await blockTracker.checkForLatestBlock();
     }
     return undefined;
   });

--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -24,15 +24,15 @@ type ValidPropertyType = string | number | symbol;
 /**
  * Determines whether the given object has the given property.
  *
- * @param object - The object to check.
+ * @param objectToCheck - The object to check.
  * @param property - The property to look for.
  * @returns - Whether the object has the property.
  */
-function hasProperty<Property extends ValidPropertyType>(
-  object: unknown,
+function hasProperty<ObjectToCheck, Property extends ValidPropertyType>(
+  objectToCheck: ObjectToCheck,
   property: Property,
-): object is Record<Property | ValidPropertyType, unknown> {
-  return Object.hasOwnProperty.call(object, property);
+): objectToCheck is ObjectToCheck & Record<Property, unknown> {
+  return Object.hasOwnProperty.call(objectToCheck, property);
 }
 
 function getResultBlockNumber(

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -1,8 +1,10 @@
-import { createFetchConfigFromReq, PayloadWithOrigin } from '.';
+import { createFetchConfigFromReq } from '.';
 
 describe('fetch', () => {
   it('should create a fetch config from a request', async () => {
     const req = {
+      id: 1,
+      jsonrpc: '2.0' as const,
       method: 'eth_getBlockByNumber',
       params: ['0x482103', true],
     };
@@ -20,17 +22,17 @@ describe('fetch', () => {
   });
 
   it('should create a fetch config with origin header', async () => {
-    const req: PayloadWithOrigin = {
+    const request = {
+      id: 1,
+      jsonrpc: '2.0' as const,
       method: 'eth_getBlockByNumber',
       params: ['0x482103', true],
-      origin: 'happydapp.gov',
     };
-    const reqSanitized = Object.assign({}, req);
-    delete reqSanitized.origin;
+    const requestWithOrigin = { ...request, origin: 'happydapp.gov' };
     const rpcUrl = 'http://www.xyz.io/rabbit:3456?id=100';
     const originHttpHeaderKey = 'x-dapp-origin';
     const { fetchUrl, fetchParams } = createFetchConfigFromReq({
-      req,
+      req: requestWithOrigin,
       rpcUrl,
       originHttpHeaderKey,
     });
@@ -42,7 +44,7 @@ describe('fetch', () => {
         'Content-Type': 'application/json',
         'x-dapp-origin': 'happydapp.gov',
       },
-      body: JSON.stringify(reqSanitized),
+      body: JSON.stringify(request),
     });
   });
 });

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,6 +1,10 @@
-import { createAsyncMiddleware, JsonRpcMiddleware } from 'json-rpc-engine';
+import {
+  createAsyncMiddleware,
+  JsonRpcMiddleware,
+  JsonRpcRequest,
+} from 'json-rpc-engine';
 import { EthereumRpcError, ethErrors } from 'eth-rpc-errors';
-import type { Payload, Block } from './types';
+import type { Block } from './types';
 
 /* eslint-disable @typescript-eslint/no-require-imports,@typescript-eslint/no-shadow */
 const fetch = global.fetch || require('node-fetch');
@@ -18,7 +22,7 @@ const RETRIABLE_ERRORS: string[] = [
   'Failed to fetch',
 ];
 
-export interface PayloadWithOrigin extends Payload {
+export interface PayloadWithOrigin extends JsonRpcRequest<unknown> {
   origin?: string;
 }
 interface Request {
@@ -42,7 +46,7 @@ interface FetchMiddlewareFromReqOptions extends FetchMiddlewareOptions {
 export function createFetchMiddleware({
   rpcUrl,
   originHttpHeaderKey,
-}: FetchMiddlewareOptions): JsonRpcMiddleware<string[], Block> {
+}: FetchMiddlewareOptions): JsonRpcMiddleware<unknown, unknown> {
   return createAsyncMiddleware(async (req, res, _next) => {
     const { fetchUrl, fetchParams } = createFetchConfigFromReq({
       req,
@@ -135,7 +139,7 @@ export function createFetchConfigFromReq({
 
   // prepare payload
   // copy only canonical json rpc properties
-  const payload: Payload = {
+  const payload: JsonRpcRequest<unknown> = {
     id: req.id,
     jsonrpc: req.jsonrpc,
     method: req.method,

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -1,9 +1,9 @@
 import { JsonRpcMiddleware, PendingJsonRpcResponse } from 'json-rpc-engine';
-import type { Block, SafeEventEmitterProvider } from './types';
+import type { SafeEventEmitterProvider } from './types';
 
 export function providerAsMiddleware(
   provider: SafeEventEmitterProvider,
-): JsonRpcMiddleware<string[], Block> {
+): JsonRpcMiddleware<unknown, unknown> {
   return (req, res, _next, end) => {
     // send request to provider
     provider.sendAsync(
@@ -23,7 +23,7 @@ export function providerAsMiddleware(
 
 export function ethersProviderAsMiddleware(
   provider: SafeEventEmitterProvider,
-): JsonRpcMiddleware<string[], Block> {
+): JsonRpcMiddleware<unknown, unknown> {
   return (req, res, _next, end) => {
     // send request to provider
     provider.send(

--- a/src/providerFromMiddleware.ts
+++ b/src/providerFromMiddleware.ts
@@ -1,9 +1,9 @@
 import { JsonRpcEngine, JsonRpcMiddleware } from 'json-rpc-engine';
-import type { SafeEventEmitterProvider, Block } from './types';
+import type { SafeEventEmitterProvider } from './types';
 import { providerFromEngine } from './providerFromEngine';
 
 export function providerFromMiddleware(
-  middleware: JsonRpcMiddleware<string[], Block>,
+  middleware: JsonRpcMiddleware<unknown, unknown>,
 ): SafeEventEmitterProvider {
   const engine: JsonRpcEngine = new JsonRpcEngine();
   engine.push(middleware);

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -34,7 +34,7 @@ interface RetryOnEmptyMiddlewareOptions {
 export function createRetryOnEmptyMiddleware({
   provider,
   blockTracker,
-}: RetryOnEmptyMiddlewareOptions = {}): JsonRpcMiddleware<string[], Block> {
+}: RetryOnEmptyMiddlewareOptions = {}): JsonRpcMiddleware<unknown, unknown> {
   if (!provider) {
     throw Error(
       'RetryOnEmptyMiddleware - mandatory "provider" option is missing.',
@@ -54,7 +54,9 @@ export function createRetryOnEmptyMiddleware({
       return next();
     }
     // skip if not exact block references
-    let blockRef: string | undefined = req.params?.[blockRefIndex];
+    let blockRef: string | undefined = Array.isArray(req.params)
+      ? req.params[blockRefIndex]
+      : undefined;
     // omitted blockRef implies "latest"
     if (blockRef === undefined) {
       blockRef = 'latest';

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,6 @@ import {
 } from 'json-rpc-engine';
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 
-export type Payload = Partial<JsonRpcRequest<any[]>>;
-
 export interface JsonRpcRequestToCache<T> extends JsonRpcRequest<T> {
   skipCache?: boolean;
 }


### PR DESCRIPTION
The types of all middleware have been updated to remove assumptions about the parameter and response types. Previously the parameters were all assumed to be `string[]` and the response results were assumed to be `Block`, but neither of those are true in practice.

Fixes #176