### PR TITLE
Update `eth-block-tracker` from v5 to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@metamask/utils": "^3.0.3",
     "btoa": "^1.2.1",
     "clone": "^2.1.1",
-    "eth-block-tracker": "^5.0.1",
+    "eth-block-tracker": "^6.1.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "json-stable-stringify": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,7 +875,7 @@ __metadata:
     eslint-plugin-jest: ^24.1.3
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.3.1
-    eth-block-tracker: ^5.0.1
+    eth-block-tracker: ^6.1.0
     eth-rpc-errors: ^4.0.3
     jest: ^27.5.1
     json-rpc-engine: ^6.1.0
@@ -912,7 +912,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^3.0.3":
+"@metamask/utils@npm:^3.0.1, @metamask/utils@npm:^3.0.3":
   version: 3.4.1
   resolution: "@metamask/utils@npm:3.4.1"
   dependencies:
@@ -2812,14 +2812,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eth-block-tracker@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "eth-block-tracker@npm:5.0.1"
+"eth-block-tracker@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "eth-block-tracker@npm:6.1.0"
   dependencies:
     "@metamask/safe-event-emitter": ^2.0.0
+    "@metamask/utils": ^3.0.1
     json-rpc-random-id: ^1.0.1
     pify: ^3.0.0
-  checksum: 83b2dd28fb7f12d644f1c1bc72011fb6bb683012489973e31171d445a34ddf6a1c167be4e4232bf7eb65144f08d92705795cf6b371c5aa6a8e78ebf48e4d5654
+  checksum: 33ee6375a26822649d1e9ac24a3c39d70338eb505715f72b9102fb82e40d7a48902b4a7dd4a33bb4f121b79707c5ab045777507a2881cfcdb385c8ccbb3ac2a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The breaking changes are changes to the `BaseBlockTracker` class (which is not used here), and updating the minimum supported Node.js version to v14. Neither affects how this package is used here.