### PR TITLE
Remove return value from `timeout`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -135,7 +135,7 @@ module.exports = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./test/setupAfterEnv.ts'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -4,6 +4,7 @@ import {
   JsonRpcRequest,
 } from 'json-rpc-engine';
 import { EthereumRpcError, ethErrors } from 'eth-rpc-errors';
+import { timeout } from './utils/timeout';
 import type { Block } from './types';
 
 const RETRIABLE_ERRORS: string[] = [
@@ -222,8 +223,4 @@ function createTimeoutError(): EthereumRpcError<unknown> {
   let msg = `Gateway timeout. The request took too long to process. `;
   msg += `This can happen when querying logs over too wide a block range.`;
   return ethErrors.rpc.internal({ message: msg });
-}
-
-function timeout(duration: number): Promise<NodeJS.Timeout> {
-  return new Promise((resolve) => setTimeout(resolve, duration));
 }

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -8,6 +8,7 @@ import {
 import pify from 'pify';
 import { projectLogger, createModuleLogger } from './logging-utils';
 import { blockTagParamIndex } from './utils/cache';
+import { timeout } from './utils/timeout';
 import { Block, SafeEventEmitterProvider } from './types';
 
 //
@@ -141,8 +142,4 @@ async function retry(
   }
   log('Retries exhausted');
   throw new Error('RetryOnEmptyMiddleware - retries exhausted');
-}
-
-function timeout(duration: number): Promise<NodeJS.Timeout> {
-  return new Promise((resolve) => setTimeout(resolve, duration));
 }

--- a/src/utils/timeout.test.ts
+++ b/src/utils/timeout.test.ts
@@ -1,0 +1,58 @@
+import { nextTick } from 'process';
+import { timeout } from './timeout';
+
+describe('timeout', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not resolve in the current event loop', async () => {
+    const winner = await Promise.race([
+      (async () => {
+        await timeout(0);
+        return 'timeout';
+      })(),
+      (async () => {
+        // nextTick runs immediately at the start of the next event loop
+        await new Promise((resolve) => nextTick(resolve));
+        return 'nextTick';
+      })(),
+    ]);
+
+    expect(winner).toBe('nextTick');
+  });
+
+  it('resolves in the next event loop', async () => {
+    const winner = await Promise.race([
+      (async () => {
+        await timeout(0);
+        return 'timeout';
+      })(),
+      (async () => {
+        // setImmediate will run all queued functions
+        await new Promise((resolve) => setImmediate(resolve));
+        return 'setImmediate';
+      })(),
+    ]);
+
+    expect(winner).toBe('setImmediate');
+  });
+
+  it('does not resolve before given duration', async () => {
+    jest.useFakeTimers();
+    const promise = timeout(100);
+
+    jest.advanceTimersByTime(50);
+
+    expect(promise).toNeverResolve();
+  });
+
+  it('resolves after the given duration', async () => {
+    jest.useFakeTimers();
+    const promise = timeout(100);
+
+    jest.advanceTimersByTime(100);
+
+    expect(await promise).toBeUndefined();
+  });
+});

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,9 @@
+/**
+ * Wait the specified number of milliseconds.
+ *
+ * @param duration - The number of milliseconds to wait.
+ * @returns A promise that resolves after the specified amount of time.
+ */
+export function timeout(duration: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}

--- a/test/setupAfterEnv.ts
+++ b/test/setupAfterEnv.ts
@@ -1,0 +1,74 @@
+const UNRESOLVED = Symbol('timedOut');
+// Store this in case it gets stubbed later
+const originalSetTimeout = global.setTimeout;
+const TIME_TO_WAIT_UNTIL_UNRESOLVED = 100;
+
+/**
+ * Produces a sort of dummy promise which can be used in conjunction with a
+ * "real" promise to determine whether the "real" promise was ever resolved. If
+ * the promise that is produced by this function resolves first, then the other
+ * one must be unresolved.
+ *
+ * @param duration - How long to wait before resolving the promise returned by
+ * this function.
+ * @returns A promise that resolves to a symbol.
+ */
+const treatUnresolvedAfter = (duration: number): Promise<typeof UNRESOLVED> => {
+  return new Promise((resolve) => {
+    originalSetTimeout(resolve, duration, UNRESOLVED);
+  });
+};
+
+expect.extend({
+  /**
+   * Tests that the given promise is never fulfilled or rejected past a certain
+   * amount of time (which is the default time that Jest tests wait before
+   * timing out as configured in the Jest configuration file).
+   *
+   * Inspired by <https://stackoverflow.com/a/68409467/260771>.
+   *
+   * @param promise - The promise to test.
+   * @returns The result of the matcher.
+   */
+  async toNeverResolve(promise: Promise<any>) {
+    if (this.isNot) {
+      throw new Error(
+        'Using `.not.toNeverResolve(...)` is not supported. ' +
+          'You probably want to either `await` the promise and test its ' +
+          'resolution value or use `.rejects` to test its rejection value instead.',
+      );
+    }
+
+    let resolutionValue: any;
+    let rejectionValue: any;
+    try {
+      resolutionValue = await Promise.race([
+        promise,
+        treatUnresolvedAfter(TIME_TO_WAIT_UNTIL_UNRESOLVED),
+      ]);
+    } catch (e) {
+      rejectionValue = e;
+    }
+
+    return resolutionValue === UNRESOLVED
+      ? {
+          message: () =>
+            `Expected promise to resolve after ${TIME_TO_WAIT_UNTIL_UNRESOLVED}ms, but it did not`,
+          pass: true,
+        }
+      : {
+          message: () => {
+            return `Expected promise to never resolve after ${TIME_TO_WAIT_UNTIL_UNRESOLVED}ms, but it ${
+              rejectionValue
+                ? `was rejected with ${rejectionValue}`
+                : `resolved with ${resolutionValue}`
+            }`;
+          },
+          pass: false,
+        };
+  },
+});
+
+// Export something so that TypeScript thinks that we are performing type
+// augmentation
+export {};

--- a/test/setupAfterEnv.ts
+++ b/test/setupAfterEnv.ts
@@ -69,6 +69,5 @@ expect.extend({
   },
 });
 
-// Export something so that TypeScript thinks that we are performing type
-// augmentation
+// Export something so that TypeScript knows to interpret this as a module
 export {};

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,13 @@
+declare global {
+  // Using `namespace` here is okay because this is how the Jest types are
+  // defined.
+  namespace jest {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
+    interface Matchers<R, T = {}> {
+      toNeverResolve(): Promise<R>;
+    }
+  }
+}
+
+// Export something so that TypeScript knows to interpret this as a module
+export {};

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,8 +2,7 @@ declare global {
   // Using `namespace` here is okay because this is how the Jest types are
   // defined.
   namespace jest {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types
-    interface Matchers<R, T = {}> {
+    interface Matchers<R> {
       toNeverResolve(): Promise<R>;
     }
   }


### PR DESCRIPTION
The `timeout` function no longer returns a timer. This was simplified so that we'd have one less reliance upon a Node.js type/API in this library, as we use this in-browser. That return type wasn't used anyway.

Tests and documentation have been added. The Jest `toNeverResolve` matcher has been migrated here from the core repository for use in the `timeout` tests.