### PR TITLE
Remove unnecessary `suppressUnauthorized` option

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -22,12 +22,7 @@ export interface TypedMessageParams extends MessageParams {
 }
 
 export interface WalletMiddlewareOptions {
-  getAccounts: (
-    req: JsonRpcRequest<unknown>,
-    options?: {
-      suppressUnauthorized?: boolean;
-    },
-  ) => Promise<string[]>;
+  getAccounts: (req: JsonRpcRequest<unknown>) => Promise<string[]>;
   processDecryptMessage?: (
     msgParams: MessageParams,
     req: JsonRpcRequest<unknown>,
@@ -383,12 +378,9 @@ export function createWalletMiddleware({
       address.length > 0 &&
       resemblesAddress(address)
     ) {
-      // ensure address is included in provided accounts. `suppressUnauthorized: false` is passed to `getAccounts`
-      // so that an "unauthorized" error is thrown if the requester does not have the `eth_accounts`
+      // Ensure that an "unauthorized" error is thrown if the requester does not have the `eth_accounts`
       // permission.
-      const accounts: string[] = await getAccounts(req, {
-        suppressUnauthorized: false,
-      });
+      const accounts = await getAccounts(req);
       const normalizedAccounts: string[] = accounts.map((_address) =>
         _address.toLowerCase(),
       );


### PR DESCRIPTION
The `suppressUnauthorized` option has been removed from the type signature of the `getAccounts` parameter accepted by the `wallet` middleware.

This option was added in #116 to fix an extension bug, but it was never used in practice. The linked extension change used the wrong parameter name (`suppressUnauthorizedError`), so this was always unset. We didn't notice because it also wasn't needed to fix the bug; the `resemblesAddress` condition added in that same PR was sufficient.