### PR TITLE
Update `eth-block-tracker` to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@metamask/eth-sig-util": "^5.0.0",
     "@metamask/utils": "^3.0.3",
     "clone": "^2.1.1",
-    "eth-block-tracker": "^6.1.0",
+    "eth-block-tracker": "^7.0.0",
     "eth-rpc-errors": "^4.0.3",
     "json-rpc-engine": "^6.1.0",
     "pify": "^3.0.0",

--- a/src/block-cache.test.ts
+++ b/src/block-cache.test.ts
@@ -1,4 +1,4 @@
-import { PollingBlockTracker, Provider } from 'eth-block-tracker';
+import { PollingBlockTracker } from 'eth-block-tracker';
 import { JsonRpcEngine } from 'json-rpc-engine';
 import pify from 'pify';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
@@ -13,7 +13,7 @@ function createTestSetup() {
   const provider = providerFromEngine(engine);
 
   const blockTracker = new PollingBlockTracker({
-    provider: provider as Provider,
+    provider,
   });
 
   return { engine, provider, blockTracker };

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -1,4 +1,4 @@
-import { PollingBlockTracker, Provider } from 'eth-block-tracker';
+import { PollingBlockTracker } from 'eth-block-tracker';
 import { JsonRpcEngine, JsonRpcMiddleware } from 'json-rpc-engine';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
@@ -458,7 +458,7 @@ async function withTestSetup<T>(
   const engine = new JsonRpcEngine();
   const provider = providerFromEngine(engine);
   const blockTracker = new PollingBlockTracker({
-    provider: provider as Provider,
+    provider,
   });
 
   const {

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -1,4 +1,4 @@
-import { PollingBlockTracker, Provider } from 'eth-block-tracker';
+import { PollingBlockTracker } from 'eth-block-tracker';
 import {
   JsonRpcEngine,
   JsonRpcMiddleware,
@@ -647,7 +647,7 @@ async function withTestSetup<T>(
   const engine = new JsonRpcEngine();
   const provider = providerFromEngine(engine);
   const blockTracker = new PollingBlockTracker({
-    provider: provider as Provider,
+    provider,
   });
 
   const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,7 +873,7 @@ __metadata:
     eslint-plugin-jest: ^24.1.3
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^3.3.1
-    eth-block-tracker: ^6.1.0
+    eth-block-tracker: ^7.0.0
     eth-rpc-errors: ^4.0.3
     jest: ^27.5.1
     json-rpc-engine: ^6.1.0
@@ -2803,15 +2803,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eth-block-tracker@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "eth-block-tracker@npm:6.1.0"
+"eth-block-tracker@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "eth-block-tracker@npm:7.0.0"
   dependencies:
+    "@metamask/eth-json-rpc-provider": ^1.0.0
     "@metamask/safe-event-emitter": ^2.0.0
     "@metamask/utils": ^3.0.1
     json-rpc-random-id: ^1.0.1
     pify: ^3.0.0
-  checksum: 33ee6375a26822649d1e9ac24a3c39d70338eb505715f72b9102fb82e40d7a48902b4a7dd4a33bb4f121b79707c5ab045777507a2881cfcdb385c8ccbb3ac2a0
+  checksum: b76f6ba022947eec0161e5592bc5386e8f05bff8a2c3e0e10c76bce21bc51900ef1cb153eb8bf31858fb0027e929c6a85a159bdf84aa1e3ef77b24e53e82ba84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The package `eth-block-tracker` has been updated to v7. This release included two breaking changes: the removal of the `Provider` type, and a change to the expected type of the `provider` constructor option.

We were already using a provider of the expected type, and we only used the removed `Provider` type for some unnecessary casts. Those casts have been removed.