### PR TITLE
deps: @metamask/eth-sig-util@^5.0.0->^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/eth-json-rpc-provider": "^1.0.0",
-    "@metamask/eth-sig-util": "^5.0.0",
+    "@metamask/eth-sig-util": "^6.0.0",
     "@metamask/utils": "^5.0.1",
     "clone": "^2.1.1",
     "eth-block-tracker": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,7 +973,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-json-rpc-provider": ^1.0.0
-    "@metamask/eth-sig-util": ^5.0.0
+    "@metamask/eth-sig-util": ^6.0.0
     "@metamask/utils": ^5.0.1
     "@types/btoa": ^1.2.3
     "@types/clone": ^2.1.0
@@ -1016,9 +1016,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "@metamask/eth-sig-util@npm:5.1.0"
+"@metamask/eth-sig-util@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "@metamask/eth-sig-util@npm:6.0.0"
   dependencies:
     "@ethereumjs/util": ^8.0.6
     bn.js: ^4.12.0
@@ -1026,7 +1026,7 @@ __metadata:
     ethjs-util: ^0.1.6
     tweetnacl: ^1.0.3
     tweetnacl-util: ^0.15.1
-  checksum: c639e3bf91625faeb0230a6314f0b2d05e8f5e2989542d3e0eed1d21b7b286e1860f68629870fd7e568c1a599b3993c4210403fb4c84a625fb1e75ef676eab4f
+  checksum: 76c173faed20d0d896561dbf3eb4ec3173e33288bf8844919643fd3e9fb6bc78f1ba8bd8a82252f4d13526ded4cc1aee27ae78f5b32642d9f97ef15fa230a12e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replaces #215 .

This upgrades `@metamask/eth-sig-util` from v5 to v6.