### PR TITLE
Revert error should not be retried

### DIFF
--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -1,8 +1,8 @@
-import { errorCodes } from '@metamask/rpc-errors';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
+import { errorCodes } from '@metamask/rpc-errors';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 import { PollingBlockTracker } from 'eth-block-tracker';
 

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -654,10 +654,7 @@ describe('createRetryOnEmptyMiddleware', () => {
             {
               request,
               response: () => {
-                throw {
-                  code: errorCodes.rpc.invalidInput,
-                  message: 'execution reverted',
-                } as any;
+                throw rpcErrors.invalidInput('execution reverted');
               },
             },
           ]);

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -2,7 +2,7 @@ import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import { errorCodes } from '@metamask/rpc-errors';
+import { errorCodes, rpcErrors } from '@metamask/rpc-errors';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 import { PollingBlockTracker } from 'eth-block-tracker';
 
@@ -647,7 +647,7 @@ describe('createRetryOnEmptyMiddleware', () => {
             id: 123,
             jsonrpc: '2.0',
             method: 'eth_call',
-            params: buildMockParamsWithoutBlockParamAt(2, '100'),
+            params: buildMockParamsWithBlockParamAt(1, '100'),
           };
           stubProviderRequests(provider, [
             buildStubForBlockNumberRequest(),

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -204,8 +204,8 @@ describe('createRetryOnEmptyMiddleware', () => {
                       id: req.id,
                       jsonrpc: '2.0',
                       error: {
-                        code: errorCodes.rpc.invalidInput,
-                        message: 'execution reverted',
+                        code: -1,
+                        message: 'oops',
                       },
                     };
                   },

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -78,7 +78,6 @@ export function createRetryOnEmptyMiddleware({
     if (Number.isNaN(blockRefNumber)) {
       return next();
     }
-
     // lookup latest block
     const latestBlockNumberHex: string = await blockTracker.getLatestBlock();
     const latestBlockNumber: number = Number.parseInt(
@@ -104,7 +103,6 @@ export function createRetryOnEmptyMiddleware({
     // create child request with specific block-ref
     const childRequest = klona(req);
     // attempt child request until non-empty response is received
-
     const childResponse: PendingJsonRpcResponse<Block> = await retry(
       10,
       async () => {

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -141,9 +141,9 @@ async function retry(
   for (let index = 0; index < maxRetries; index++) {
     try {
       return await asyncFn();
-    } catch (err: any) {
+    } catch (err: unknown) {
       if (isExecutionRevertedError(err)) {
-        throw err as unknown;
+        throw err;
       }
       log('(call %i) Request failed, waiting 1s to retry again...', index + 1);
       await timeout(1000);

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -140,7 +140,10 @@ async function retry(
   for (let index = 0; index < maxRetries; index++) {
     try {
       return await asyncFn();
-    } catch (err) {
+    } catch (err: any) {
+      if (err.code === -32000) {
+        throw err;
+      }
       log('(call %i) Request failed, waiting 1s to retry again...', index + 1);
       await timeout(1000);
     }

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -143,7 +143,7 @@ async function retry(
       return await asyncFn();
     } catch (err: unknown) {
       if (isExecutionRevertedError(err)) {
-        throw err;
+        throw err as unknown;
       }
       log('(call %i) Request failed, waiting 1s to retry again...', index + 1);
       await timeout(1000);

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -145,7 +145,7 @@ async function retry(
       return await asyncFn();
     } catch (err: any) {
       if (isExecutionRevertedError(err)) {
-        throw err;
+        throw err as unknown;
       }
       log('(call %i) Request failed, waiting 1s to retry again...', index + 1);
       await timeout(1000);

--- a/src/utils/error.test.ts
+++ b/src/utils/error.test.ts
@@ -7,7 +7,7 @@ const executionRevertedError = {
   message: 'execution reverted',
 };
 
-describe('error', () => {
+describe('isExecutionRevertedError', () => {
   it('return false if object is not valid JSON RPC error', async () => {
     const result = isExecutionRevertedError({ test: 'dummy' });
     expect(result).toBe(false);

--- a/src/utils/error.test.ts
+++ b/src/utils/error.test.ts
@@ -1,0 +1,36 @@
+import { errorCodes } from '@metamask/rpc-errors';
+
+import { isExecutionRevertedError } from './error';
+
+const executionRevertedError = {
+  code: errorCodes.rpc.invalidInput,
+  message: 'execution reverted',
+};
+
+describe('error', () => {
+  it('return false if object is not valid JSON RPC error', async () => {
+    const result = isExecutionRevertedError({ test: 'dummy' });
+    expect(result).toBe(false);
+  });
+
+  it('return false if error code is not same as errorCodes.rpc.invalidInput', async () => {
+    const result = isExecutionRevertedError({
+      ...executionRevertedError,
+      code: 123,
+    });
+    expect(result).toBe(false);
+  });
+
+  it('return false if error message is not "execution reverted"', async () => {
+    const result = isExecutionRevertedError({
+      ...executionRevertedError,
+      message: 'test',
+    });
+    expect(result).toBe(false);
+  });
+
+  it('return true for correct executionRevertedError', async () => {
+    const result = isExecutionRevertedError(executionRevertedError);
+    expect(result).toBe(true);
+  });
+});

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,13 @@
+import { isJsonRpcError } from '@metamask/utils';
+import type { JsonRpcError } from '@metamask/utils';
+import { errorCodes } from '@metamask/rpc-errors';
+
+export function isExecutionRevertedError(
+  error: unknown,
+): error is JsonRpcError {
+  return (
+    isJsonRpcError(error) &&
+    error.code === errorCodes.rpc.invalidInput &&
+    error.message === 'execution reverted'
+  );
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,6 @@
+import { errorCodes } from '@metamask/rpc-errors';
 import { isJsonRpcError } from '@metamask/utils';
 import type { JsonRpcError } from '@metamask/utils';
-import { errorCodes } from '@metamask/rpc-errors';
 
 export function isExecutionRevertedError(
   error: unknown,

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -121,11 +121,12 @@ export function buildMockParamsWithBlockParamAt(
  */
 export function buildMockParamsWithoutBlockParamAt(
   blockParamIndex: number,
+  value?: string,
 ): string[] {
   const params = [];
 
   for (let i = 0; i < blockParamIndex; i++) {
-    params.push('some value');
+    params.push(value ?? 'some value');
   }
 
   return params;

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -121,12 +121,11 @@ export function buildMockParamsWithBlockParamAt(
  */
 export function buildMockParamsWithoutBlockParamAt(
   blockParamIndex: number,
-  value?: string,
 ): string[] {
   const params = [];
 
   for (let i = 0; i < blockParamIndex; i++) {
-    params.push(value ?? 'some value');
+    params.push('some value');
   }
 
   return params;


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/MetaMask-planning/issues/1461

This is an issue brought up by blockaid team, in case of revert we should not retry and send back original error.