### PR TITLE
Fix rate limit error code in fetch.ts

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -107,7 +107,7 @@ function checkForHttpErrors(fetchRes: Response): void {
     case 405:
       throw rpcErrors.methodNotFound();
 
-    case 418:
+    case 429:
       throw createRatelimitError();
 
     case 503:


### PR DESCRIPTION
According to the [HTML list of error codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes), 429 is what is returned on rate limiting errors (empirically, Arbitrum's RPC node also uses 429)

I believe the current value is a mistake and was meant as a placeholder, given 418 is the joke error code [418 I'm a teapot](https://en.wikipedia.org/wiki/HTTP_418)

I could be wrong and maybe some service returns this value. Strangely, this `418` value persists all the way back since 2017 when [the file was originally created](https://github.com/MetaMask/eth-json-rpc-middleware/commit/2c76d392cf017a4a307cafbd2b29ada7f8c80db7#diff-3fc6f1265a180d15035618e36ca1da88d092bacb4fc10a423938fa62e4f5f58fR72), so I don't know the context for this this was used