### PR TITLE
Add `signatureMethod` property to `MessageParams`

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -265,6 +265,7 @@ describe('wallet', () => {
       expect(witnessedMsgParams[0]).toStrictEqual({
         from: testAddresses[0],
         data: message,
+        signatureMethod: 'eth_signTypedData',
       });
     });
 
@@ -352,6 +353,7 @@ describe('wallet', () => {
       expect(witnessedMsgParams[0]).toStrictEqual({
         data: message,
         from: testAddresses[0],
+        signatureMethod: 'personal_sign',
       });
     });
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -32,7 +32,7 @@ export type TransactionParams = {
 
 export type MessageParams = TransactionParams & {
   data: string;
-  signatureMethod: string;
+  signatureMethod?: string;
 };
 
 export type TypedMessageParams = MessageParams & {
@@ -42,7 +42,7 @@ export type TypedMessageParams = MessageParams & {
 export interface WalletMiddlewareOptions {
   getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
   processDecryptMessage?: (
-    msgParams: Omit<MessageParams, 'signatureMethod'>,
+    msgParams: MessageParams,
     req: JsonRpcRequest,
   ) => Promise<string>;
   processEncryptionPublicKey?: (
@@ -430,7 +430,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
     const ciphertext: string = params[0];
     const address: string = await validateAndNormalizeKeyholder(params[1], req);
     const extraParams = params[2] || {};
-    const msgParams: Omit<MessageParams, 'signatureMethod'> = {
+    const msgParams: MessageParams = {
       ...extraParams,
       from: address,
       data: ciphertext,

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -32,6 +32,7 @@ export type TransactionParams = {
 
 export type MessageParams = TransactionParams & {
   data: string;
+  signatureMethod: string;
 };
 
 export type TypedMessageParams = MessageParams & {
@@ -41,7 +42,7 @@ export type TypedMessageParams = MessageParams & {
 export interface WalletMiddlewareOptions {
   getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
   processDecryptMessage?: (
-    msgParams: MessageParams,
+    msgParams: Omit<MessageParams, 'signatureMethod'>,
     req: JsonRpcRequest,
   ) => Promise<string>;
   processEncryptionPublicKey?: (
@@ -212,6 +213,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       ...extraParams,
       from: address,
       data: message,
+      signatureMethod: 'eth_sign',
     };
 
     res.result = await processEthSignMessage(msgParams, req);
@@ -241,6 +243,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       ...extraParams,
       from: address,
       data: message,
+      signatureMethod: 'eth_signTypedData',
     };
 
     res.result = await processTypedMessage(msgParams, req, version);
@@ -270,6 +273,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       data: message,
       from: address,
       version,
+      signatureMethod: 'eth_signTypedData_v3',
     };
 
     res.result = await processTypedMessageV3(msgParams, req, version);
@@ -299,6 +303,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       data: message,
       from: address,
       version,
+      signatureMethod: 'eth_signTypedData_v4',
     };
 
     res.result = await processTypedMessageV4(msgParams, req, version);
@@ -354,6 +359,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       ...extraParams,
       from: address,
       data: message,
+      signatureMethod: 'personal_sign',
     };
 
     // eslint-disable-next-line require-atomic-updates
@@ -424,7 +430,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
     const ciphertext: string = params[0];
     const address: string = await validateAndNormalizeKeyholder(params[1], req);
     const extraParams = params[2] || {};
-    const msgParams: MessageParams = {
+    const msgParams: Omit<MessageParams, 'signatureMethod'> = {
       ...extraParams,
       from: address,
       data: ciphertext,


### PR DESCRIPTION
The `signatureMethod` property was introduced because it will be useful for signature insight snaps to determine which signature scheme to provide insights for. Currently this would be for all our supported signing methods, but in the future can be applied to registered signer snaps.