### PR TITLE
Update message types

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -2,7 +2,7 @@ import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import pify from 'pify';
 
-import type { TransactionParams, MessageParams } from '.';
+import type { TransactionParams, MessageParams, TypedMessageV1Params } from '.';
 import { createWalletMiddleware } from '.';
 
 const testAddresses = [
@@ -237,8 +237,8 @@ describe('wallet', () => {
     it('should sign with a valid address', async () => {
       const { engine } = createTestSetup();
       const getAccounts = async () => testAddresses.slice();
-      const witnessedMsgParams: MessageParams[] = [];
-      const processTypedMessage = async (msgParams: MessageParams) => {
+      const witnessedMsgParams: TypedMessageV1Params[] = [];
+      const processTypedMessage = async (msgParams: TypedMessageV1Params) => {
         witnessedMsgParams.push(msgParams);
         return testMsgSig;
       };
@@ -272,8 +272,8 @@ describe('wallet', () => {
     it('should throw with invalid address', async () => {
       const { engine } = createTestSetup();
       const getAccounts = async () => testAddresses.slice();
-      const witnessedMsgParams: MessageParams[] = [];
-      const processTypedMessage = async (msgParams: MessageParams) => {
+      const witnessedMsgParams: TypedMessageV1Params[] = [];
+      const processTypedMessage = async (msgParams: TypedMessageV1Params) => {
         witnessedMsgParams.push(msgParams);
         return testMsgSig;
       };
@@ -299,8 +299,8 @@ describe('wallet', () => {
     it('should throw with unknown address', async () => {
       const { engine } = createTestSetup();
       const getAccounts = async () => testAddresses.slice();
-      const witnessedMsgParams: MessageParams[] = [];
-      const processTypedMessage = async (msgParams: MessageParams) => {
+      const witnessedMsgParams: TypedMessageV1Params[] = [];
+      const processTypedMessage = async (msgParams: TypedMessageV1Params) => {
         witnessedMsgParams.push(msgParams);
         return testMsgSig;
       };

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -266,6 +266,7 @@ describe('wallet', () => {
         from: testAddresses[0],
         data: message,
         signatureMethod: 'eth_signTypedData',
+        version: "V1",
       });
     });
 

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -266,7 +266,7 @@ describe('wallet', () => {
         from: testAddresses[0],
         data: message,
         signatureMethod: 'eth_signTypedData',
-        version: "V1",
+        version: 'V1',
       });
     });
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -39,6 +39,8 @@ export type TypedMessageParams = MessageParams & {
   version: string;
 };
 
+export type TypedMessageV1Params = Omit<TypedMessageParams, 'data'> & { data: Record<string, unknown>[]; };
+
 export interface WalletMiddlewareOptions {
   getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
   processDecryptMessage?: (
@@ -66,7 +68,7 @@ export interface WalletMiddlewareOptions {
     req: JsonRpcRequest,
   ) => Promise<string>;
   processTypedMessage?: (
-    msgParams: MessageParams,
+    msgParams: TypedMessageV1Params,
     req: JsonRpcRequest,
     version: string,
   ) => Promise<string>;
@@ -234,16 +236,17 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       throw rpcErrors.invalidInput();
     }
 
-    const params = req.params as [string, string, Record<string, string>?];
+    const params = req.params as [Record<string, unknown>[], string, Record<string, string>?];
     const message = params[0];
     const address = await validateAndNormalizeKeyholder(params[1], req);
     const version = 'V1';
     const extraParams = params[2] || {};
-    const msgParams: MessageParams = {
+    const msgParams: TypedMessageV1Params = {
       ...extraParams,
       from: address,
       data: message,
       signatureMethod: 'eth_signTypedData',
+      version,
     };
 
     res.result = await processTypedMessage(msgParams, req, version);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -39,7 +39,9 @@ export type TypedMessageParams = MessageParams & {
   version: string;
 };
 
-export type TypedMessageV1Params = Omit<TypedMessageParams, 'data'> & { data: Record<string, unknown>[]; };
+export type TypedMessageV1Params = Omit<TypedMessageParams, 'data'> & {
+  data: Record<string, unknown>[];
+};
 
 export interface WalletMiddlewareOptions {
   getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
@@ -236,7 +238,11 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
       throw rpcErrors.invalidInput();
     }
 
-    const params = req.params as [Record<string, unknown>[], string, Record<string, string>?];
+    const params = req.params as [
+      Record<string, unknown>[],
+      string,
+      Record<string, string>?,
+    ];
     const message = params[0];
     const address = await validateAndNormalizeKeyholder(params[1], req);
     const version = 'V1';


### PR DESCRIPTION
Wallet middleware was incorrectly assigning `TypedMessageParams` as  the type for `eth_signTypedData` message params. Updated the type and tests.