### PR TITLE
deps: eth-block-tracker@^8.0.0 -> @metamask/eth-block-tracker@9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/eth-block-tracker": "9.0.0",
     "@metamask/eth-json-rpc-provider": "^2.1.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/rpc-errors": "^6.0.0",
     "@metamask/utils": "^8.1.0",
-    "eth-block-tracker": "^8.0.0",
     "klona": "^2.0.6",
     "pify": "^5.0.0",
     "safe-stable-stringify": "^2.4.3"

--- a/src/block-cache.test.ts
+++ b/src/block-cache.test.ts
@@ -1,6 +1,6 @@
+import { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import { PollingBlockTracker } from 'eth-block-tracker';
 import pify from 'pify';
 
 import { createBlockCacheMiddleware } from '.';

--- a/src/block-cache.ts
+++ b/src/block-cache.ts
@@ -1,6 +1,6 @@
+import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
-import type { PollingBlockTracker } from 'eth-block-tracker';
 
 import { projectLogger, createModuleLogger } from './logging-utils';
 import type {

--- a/src/block-ref-rewrite.ts
+++ b/src/block-ref-rewrite.ts
@@ -1,7 +1,7 @@
+import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type { Json, JsonRpcParams } from '@metamask/utils';
-import type { PollingBlockTracker } from 'eth-block-tracker';
 
 import { blockTagParamIndex } from './utils/cache';
 

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -1,8 +1,8 @@
+import { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
-import { PollingBlockTracker } from 'eth-block-tracker';
 
 import { createBlockRefMiddleware } from '.';
 import {

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -1,3 +1,4 @@
+import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
@@ -6,7 +7,6 @@ import type {
   JsonRpcParams,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import type { PollingBlockTracker } from 'eth-block-tracker';
 import { klona } from 'klona/full';
 import pify from 'pify';
 

--- a/src/block-tracker-inspector.ts
+++ b/src/block-tracker-inspector.ts
@@ -1,3 +1,4 @@
+import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type {
@@ -5,7 +6,6 @@ import type {
   JsonRpcParams,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import type { PollingBlockTracker } from 'eth-block-tracker';
 
 import { projectLogger, createModuleLogger } from './logging-utils';
 

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -1,10 +1,10 @@
+import { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { providerFromEngine } from '@metamask/eth-json-rpc-provider';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { errorCodes, rpcErrors } from '@metamask/rpc-errors';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
-import { PollingBlockTracker } from 'eth-block-tracker';
 
 import { createRetryOnEmptyMiddleware } from '.';
 import type { ProviderRequestStub } from '../test/util/helpers';

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -1,3 +1,4 @@
+import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
@@ -6,7 +7,6 @@ import type {
   JsonRpcParams,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import type { PollingBlockTracker } from 'eth-block-tracker';
 import { klona } from 'klona/full';
 import pify from 'pify';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,12 +1022,12 @@ __metadata:
   linkType: hard
 
 "@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@metamask/rpc-errors@npm:6.1.0"
+  version: 6.2.1
+  resolution: "@metamask/rpc-errors@npm:6.2.1"
   dependencies:
-    "@metamask/utils": ^8.1.0
+    "@metamask/utils": ^8.3.0
     fast-safe-stringify: ^2.0.6
-  checksum: 9f4821d804e2fcaa8987b0958d02c6d829b7c7db49740c811cb593f381d0c4b00dabb7f1802907f1b2f6126f7c0d83ec34219183d29650f5d24df014ac72906a
+  checksum: a9223c3cb9ab05734ea0dda990597f90a7cdb143efa0c026b1a970f2094fe5fa3c341ed39b1e7623be13a96b98fb2c697ef51a2e2b87d8f048114841d35ee0a9
   languageName: node
   linkType: hard
 
@@ -1038,7 +1038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0":
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.3.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1011,17 +1011,17 @@ __metadata:
   linkType: hard
 
 "@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "@metamask/json-rpc-engine@npm:7.3.1"
+  version: 7.3.3
+  resolution: "@metamask/json-rpc-engine@npm:7.3.3"
   dependencies:
-    "@metamask/rpc-errors": ^6.1.0
+    "@metamask/rpc-errors": ^6.2.1
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.2.0
-  checksum: 4952eb4e70c0011d334fb4a9bf56aa2d68bef745c892dddd06f6ed7e6303fb95b3b60b4e32c88b6d77bfc5091acc8e71ad274f389419e4bdcc5741ef49cde87d
+    "@metamask/utils": ^8.3.0
+  checksum: 7bab8b4d2341a6243ba451bc58283f0a6905b09f7257857859848a51a795444ca6899b1a6908b15f8ed236fb574ab85a630c9cb28d127ab52c4630e496c16006
   languageName: node
   linkType: hard
 
-"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.1.0":
+"@metamask/rpc-errors@npm:^6.0.0, @metamask/rpc-errors@npm:^6.2.1":
   version: 6.2.1
   resolution: "@metamask/rpc-errors@npm:6.2.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -986,13 +986,13 @@ __metadata:
   linkType: soft
 
 "@metamask/eth-json-rpc-provider@npm:^2.1.0":
-  version: 2.3.1
-  resolution: "@metamask/eth-json-rpc-provider@npm:2.3.1"
+  version: 2.3.2
+  resolution: "@metamask/eth-json-rpc-provider@npm:2.3.2"
   dependencies:
-    "@metamask/json-rpc-engine": ^7.3.1
+    "@metamask/json-rpc-engine": ^7.3.2
     "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.2.0
-  checksum: fa0a987eb7e0dcff495489e95c358f6786a4a793a42ac900bb022027d27e6534ded743092e79a2191b9b4d760f418f39f6cfb99a5a5a0085f252016579be6865
+    "@metamask/utils": ^8.3.0
+  checksum: e6731271aad3b972d85b9230c26d35a9b88722f3bd3024675ad2f568e634e9fdfef4717ef2892f3cc512d381cf17a4e20dbd5eb808ced765082bea3379ad6ddc
   languageName: node
   linkType: hard
 
@@ -1010,7 +1010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.1":
+"@metamask/json-rpc-engine@npm:^7.1.1, @metamask/json-rpc-engine@npm:^7.3.2":
   version: 7.3.3
   resolution: "@metamask/json-rpc-engine@npm:7.3.3"
   dependencies:
@@ -1038,7 +1038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0, @metamask/utils@npm:^8.3.0":
+"@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0":
   version: 8.4.0
   resolution: "@metamask/utils@npm:8.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,8 +1039,8 @@ __metadata:
   linkType: hard
 
 "@metamask/utils@npm:^8.0.0, @metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.2.0":
-  version: 8.2.1
-  resolution: "@metamask/utils@npm:8.2.1"
+  version: 8.4.0
+  resolution: "@metamask/utils@npm:8.4.0"
   dependencies:
     "@ethereumjs/tx": ^4.2.0
     "@noble/hashes": ^1.3.1
@@ -1050,7 +1050,8 @@ __metadata:
     pony-cause: ^2.1.10
     semver: ^7.5.4
     superstruct: ^1.0.3
-  checksum: 36a714a17e4949d2040bedb28d4373a22e7e86bb797aa2d59223f9799fd76e662443bcede113719c4e200f5e9d90a9d62feafad5028fff8b9a7a85fface097ca
+    uuid: ^9.0.1
+  checksum: b0397e97bac7192f6189a8625a2dfcb56d3c2cf4dd2cb3d4e012a7e9786f04f59f6917805544bc131a6dacd2c8344e237ae43ad47429bb5eb35c6cf1248440b4
   languageName: node
   linkType: hard
 
@@ -6692,6 +6693,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-block-tracker@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/eth-block-tracker@npm:9.0.0"
+  dependencies:
+    "@metamask/eth-json-rpc-provider": ^2.1.0
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.1.0
+    json-rpc-random-id: ^1.0.1
+    pify: ^5.0.0
+  checksum: 1069ca945d04a485ca3b92cb6f2744793be9375876c4c995405ee2736e8ca68aba8ecb4a422d40341d5fa708044be4483cbd78ae87ae383c25f3214321322ad9
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@workspace:.":
   version: 0.0.0-use.local
   resolution: "@metamask/eth-json-rpc-middleware@workspace:."
@@ -939,6 +952,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
+    "@metamask/eth-block-tracker": 9.0.0
     "@metamask/eth-json-rpc-provider": ^2.1.0
     "@metamask/eth-sig-util": ^7.0.0
     "@metamask/json-rpc-engine": ^7.1.1
@@ -958,7 +972,6 @@ __metadata:
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
-    eth-block-tracker: ^8.0.0
     jest: ^27.5.1
     klona: ^2.0.6
     pify: ^5.0.0
@@ -3043,19 +3056,6 @@ __metadata:
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
-  languageName: node
-  linkType: hard
-
-"eth-block-tracker@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "eth-block-tracker@npm:8.0.0"
-  dependencies:
-    "@metamask/eth-json-rpc-provider": ^2.1.0
-    "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.1.0
-    json-rpc-random-id: ^1.0.1
-    pify: ^5.0.0
-  checksum: 3416c2ee653f81d1f71f3a9b80e04837fb516494f64ded45c053dfc24c6c6ce8dac7e5b8376cd57f52838f43a93d20a8e17d4d875e50d1e4c267543ffe0e6ad8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The package `eth-block-tracker` has been renamed to `@metamask/eth-block-tracker`. 

- Upgrade from `eth-block-tracker@^8.0.0` to `@metamask/eth-block-tracker@9.0.0`
   - `9.0.0` contains no breaking changes beyond the rename.
   - Pinning due to yet-to-be-investigated test errors caused by `9.0.1`
     - #303 
- Lockbump related transitive dependencies  

https://github.com/MetaMask/eth-block-tracker/blob/main/CHANGELOG.md

~Investigating unexpected test regressions in #303  - this pins to penultimate `@metamask/eth-block-tracker@9.0.0` in order to suss out cause.~