### PR TITLE
Bump @metamask/ dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@metamask/eth-block-tracker": "^10.0.0",
     "@metamask/eth-json-rpc-provider": "^4.0.0",
     "@metamask/eth-sig-util": "^7.0.0",
-    "@metamask/json-rpc-engine": "^8.0.2",
+    "@metamask/json-rpc-engine": "^9.0.0",
     "@metamask/rpc-errors": "^6.0.0",
     "@metamask/utils": "^8.1.0",
     "@types/bn.js": "^5.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,7 +955,7 @@ __metadata:
     "@metamask/eth-block-tracker": ^10.0.0
     "@metamask/eth-json-rpc-provider": ^4.0.0
     "@metamask/eth-sig-util": ^7.0.0
-    "@metamask/json-rpc-engine": ^8.0.2
+    "@metamask/json-rpc-engine": ^9.0.0
     "@metamask/rpc-errors": ^6.0.0
     "@metamask/utils": ^8.1.0
     "@types/bn.js": ^5.1.5
@@ -1009,17 +1009,6 @@ __metadata:
     tweetnacl: ^1.0.3
     tweetnacl-util: ^0.15.1
   checksum: 98d056bd83aeb2d29ec3de09cd18e67d97ea295a59d405a9ce3fe274badd2d4f18da1fe530a266b4c777650855ed75ecd3577decd607a561e938dd7a808c5839
-  languageName: node
-  linkType: hard
-
-"@metamask/json-rpc-engine@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "@metamask/json-rpc-engine@npm:8.0.2"
-  dependencies:
-    "@metamask/rpc-errors": ^6.2.1
-    "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.3.0
-  checksum: c240d298ad503d93922a94a62cf59f0344b6d6644a523bc8ea3c0f321bea7172b89f2747a5618e2861b2e8152ae5086b76f391a10e4566529faa50b8850c051d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Major maintenance upgrades after node 18 upgrade:
- `@metamask/eth-block-tracker@^9.0.3->^10.0.0`
- `@metamask/eth-json-rpc-provider@^3.0.2->^4.0.0`
- `@metamask/json-rpc-engine@^8.0.2->^9.0.0`

---

#### Blocked by
- [x] #312 

#### Blocking
- #314