### PR TITLE
adapt to eip-1193 provider changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/eth-block-tracker": "^10.1.0",
+    "@metamask/eth-block-tracker": "^11.0.0",
     "@metamask/eth-json-rpc-provider": "^4.1.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/json-rpc-engine": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/eth-block-tracker": "^10.0.0",
+    "@metamask/eth-block-tracker": "^10.1.0",
     "@metamask/eth-json-rpc-provider": "^4.1.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/json-rpc-engine": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@metamask/eth-block-tracker": "^10.0.0",
-    "@metamask/eth-json-rpc-provider": "^4.0.0",
+    "@metamask/eth-json-rpc-provider": "^4.1.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/json-rpc-engine": "^9.0.0",
     "@metamask/rpc-errors": "^6.0.0",

--- a/src/block-cache.test.ts
+++ b/src/block-cache.test.ts
@@ -23,11 +23,7 @@ function createTestSetup() {
 describe('block cache', () => {
   it('should cache a request and only hit the provider once', async () => {
     const { engine, provider, blockTracker } = createTestSetup();
-    const spy = jest
-      .spyOn(provider, 'sendAsync')
-      .mockImplementation((req, cb) => {
-        cb(undefined, { id: req.id, result: '0x0', jsonrpc: '2.0' });
-      });
+    const requestSpy = jest.spyOn(provider, 'request').mockResolvedValue('0x0');
     let hitCount = 0;
 
     const hitCountMiddleware = createHitTrackerMiddleware();
@@ -56,6 +52,6 @@ describe('block cache', () => {
     expect(hitCount).toBe(1);
     expect(response.result).toBe('0x0');
     expect(response2.result).toBe('0x0');
-    expect(spy).toHaveBeenCalled();
+    expect(requestSpy).toHaveBeenCalled();
   });
 });

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -116,6 +116,7 @@ describe('createBlockRefMiddleware', () => {
                   id: 1,
                   jsonrpc: '2.0',
                   result: 'something',
+                  error: undefined,
                 });
               },
             );
@@ -208,6 +209,7 @@ describe('createBlockRefMiddleware', () => {
                   id: 1,
                   jsonrpc: '2.0',
                   result: 'something',
+                  error: undefined,
                 });
               },
             );

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -106,13 +106,17 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: () => 'something',
+                    response: async () => Promise.resolve('something'),
                   }),
                 ]);
 
                 const response = await engine.handle(request);
 
-                expect(response).toBe('something');
+                expect(response).toStrictEqual({
+                  id: 1,
+                  jsonrpc: '2.0',
+                  result: 'something',
+                });
               },
             );
           });
@@ -152,7 +156,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: () => 'something',
+                    response: async () => Promise.resolve('something'),
                   }),
                 ]);
 
@@ -194,13 +198,17 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: () => 'something',
+                    response: async () => Promise.resolve('something'),
                   }),
                 ]);
 
                 const response = await engine.handle(request);
 
-                expect(response).toBe('something');
+                expect(response).toStrictEqual({
+                  id: 1,
+                  jsonrpc: '2.0',
+                  result: 'something',
+                });
               },
             );
           });
@@ -237,7 +245,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: () => 'something',
+                    response: async () => Promise.resolve('something'),
                   }),
                 ]);
 

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -112,12 +112,7 @@ describe('createBlockRefMiddleware', () => {
 
                 const response = await engine.handle(request);
 
-                expect(response).toStrictEqual({
-                  id: 1,
-                  jsonrpc: '2.0',
-                  result: 'something',
-                  error: undefined,
-                });
+                expect(response).toBe('something');
               },
             );
           });
@@ -205,12 +200,7 @@ describe('createBlockRefMiddleware', () => {
 
                 const response = await engine.handle(request);
 
-                expect(response).toStrictEqual({
-                  id: 1,
-                  jsonrpc: '2.0',
-                  result: 'something',
-                  error: undefined,
-                });
+                expect(response).toBe('something');
               },
             );
           });

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -106,11 +106,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: (req) => ({
-                      id: req.id,
-                      jsonrpc: '2.0' as const,
-                      result: 'something',
-                    }),
+                    response: () => 'something',
                   }),
                 ]);
 
@@ -161,11 +157,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: (req) => ({
-                      id: req.id,
-                      jsonrpc: '2.0' as const,
-                      result: 'something',
-                    }),
+                    response: () => 'something',
                   }),
                 ]);
 
@@ -207,11 +199,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: (req) => ({
-                      id: req.id,
-                      jsonrpc: '2.0' as const,
-                      result: 'something',
-                    }),
+                    response: () => 'something',
                   }),
                 ]);
 
@@ -259,11 +247,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: (req) => ({
-                      id: req.id,
-                      jsonrpc: '2.0' as const,
-                      result: 'something',
-                    }),
+                    response: () => 'something',
                   }),
                 ]);
 
@@ -303,13 +287,13 @@ describe('createBlockRefMiddleware', () => {
                       blockParam,
                     ),
                   };
-                  const sendAsyncSpy = stubProviderRequests(provider, [
+                  const requestSpy = stubProviderRequests(provider, [
                     buildStubForBlockNumberRequest('0x100'),
                   ]);
 
                   await engine.handle(request);
 
-                  expectProviderRequestNotToHaveBeenMade(sendAsyncSpy, request);
+                  expectProviderRequestNotToHaveBeenMade(requestSpy, request);
                 },
               );
             });
@@ -387,13 +371,13 @@ describe('createBlockRefMiddleware', () => {
             method: 'a_non_block_param_method',
             params: ['some value', '0x200'],
           };
-          const sendAsyncSpy = stubProviderRequests(provider, [
+          const requestSpy = stubProviderRequests(provider, [
             buildStubForBlockNumberRequest('0x100'),
           ]);
 
           await engine.handle(request);
 
-          expectProviderRequestNotToHaveBeenMade(sendAsyncSpy, request);
+          expectProviderRequestNotToHaveBeenMade(requestSpy, request);
         },
       );
     });

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -10,7 +10,7 @@ import {
   stubProviderRequests,
   buildStubForBlockNumberRequest,
   buildStubForGenericRequest,
-  buildFinalMiddlewareWithDefaultResponse,
+  buildFinalMiddlewareWithDefaultResult,
   buildMockParamsWithoutBlockParamAt,
   expectProviderRequestNotToHaveBeenMade,
 } from '../test/util/helpers';
@@ -106,7 +106,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => 'something',
+                    result: async () => 'something',
                   }),
                 ]);
 
@@ -123,7 +123,7 @@ describe('createBlockRefMiddleware', () => {
           });
 
           it('does not proceed to the next middleware after making a request through the provider', async () => {
-            const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+            const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
             await withTestSetup(
               {
@@ -157,7 +157,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => 'something',
+                    result: async () => 'something',
                   }),
                 ]);
 
@@ -199,7 +199,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => 'something',
+                    result: async () => 'something',
                   }),
                 ]);
 
@@ -216,7 +216,7 @@ describe('createBlockRefMiddleware', () => {
           });
 
           it('does not proceed to the next middleware after making a request through the provider', async () => {
-            const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+            const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
             await withTestSetup(
               {
@@ -247,7 +247,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => 'something',
+                    result: async () => 'something',
                   }),
                 ]);
 
@@ -263,7 +263,7 @@ describe('createBlockRefMiddleware', () => {
           'if the block param is something other than "latest", like %o',
           (blockParam) => {
             it('does not make a direct request through the provider', async () => {
-              const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+              const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
               await withTestSetup(
                 {
@@ -299,7 +299,7 @@ describe('createBlockRefMiddleware', () => {
             });
 
             it('proceeds to the next middleware', async () => {
-              const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+              const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
               await withTestSetup(
                 {
@@ -350,7 +350,7 @@ describe('createBlockRefMiddleware', () => {
 
   describe('when the RPC method does not take a block parameter', () => {
     it('does not make a direct request through the provider', async () => {
-      const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+      const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
       await withTestSetup(
         {
@@ -383,7 +383,7 @@ describe('createBlockRefMiddleware', () => {
     });
 
     it('proceeds to the next middleware', async () => {
-      const finalMiddleware = buildFinalMiddlewareWithDefaultResponse();
+      const finalMiddleware = buildFinalMiddlewareWithDefaultResult();
 
       await withTestSetup(
         {
@@ -449,7 +449,7 @@ async function withTestSetup<T>(
 
   const {
     middlewareUnderTest,
-    otherMiddleware = [buildFinalMiddlewareWithDefaultResponse()],
+    otherMiddleware = [buildFinalMiddlewareWithDefaultResult()],
   } = configureMiddleware({ engine, provider, blockTracker });
 
   for (const middleware of [middlewareUnderTest, ...otherMiddleware]) {

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -106,7 +106,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => Promise.resolve('something'),
+                    response: async () => 'something',
                   }),
                 ]);
 
@@ -157,7 +157,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => Promise.resolve('something'),
+                    response: async () => 'something',
                   }),
                 ]);
 
@@ -199,7 +199,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => Promise.resolve('something'),
+                    response: async () => 'something',
                   }),
                 ]);
 
@@ -247,7 +247,7 @@ describe('createBlockRefMiddleware', () => {
                         '0x100',
                       ),
                     },
-                    response: async () => Promise.resolve('something'),
+                    response: async () => 'something',
                   }),
                 ]);
 

--- a/src/block-ref.test.ts
+++ b/src/block-ref.test.ts
@@ -116,7 +116,6 @@ describe('createBlockRefMiddleware', () => {
                   id: 1,
                   jsonrpc: '2.0',
                   result: 'something',
-                  error: undefined,
                 });
               },
             );
@@ -209,7 +208,6 @@ describe('createBlockRefMiddleware', () => {
                   id: 1,
                   jsonrpc: '2.0',
                   result: 'something',
-                  error: undefined,
                 });
               },
             );

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -63,7 +63,7 @@ export function createBlockRefMiddleware({
 
     // perform child request
     log('Performing another request %o', childRequest);
-    // copy child response onto original response
+    // copy child result onto original response
     try {
       const childResult = await provider.request<JsonRpcParams, Block>(
         childRequest,

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -2,7 +2,6 @@ import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
-import { serializeError } from '@metamask/rpc-errors';
 import type { Json, JsonRpcParams } from '@metamask/utils';
 import { klona } from 'klona/full';
 
@@ -65,14 +64,7 @@ export function createBlockRefMiddleware({
     // perform child request
     log('Performing another request %o', childRequest);
     // copy child result onto original response
-    try {
-      const childResult = await provider.request<JsonRpcParams, Block>(
-        childRequest,
-      );
-      res.result = childResult;
-    } catch (error) {
-      res.error = serializeError(error);
-    }
+    res.result = await provider.request<JsonRpcParams, Block>(childRequest);
 
     return undefined;
   });

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -2,13 +2,8 @@ import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
-import type {
-  Json,
-  JsonRpcParams,
-  PendingJsonRpcResponse,
-} from '@metamask/utils';
+import type { Json, JsonRpcParams } from '@metamask/utils';
 import { klona } from 'klona/full';
-import pify from 'pify';
 
 import { projectLogger, createModuleLogger } from './logging-utils';
 import type { Block } from './types';
@@ -68,12 +63,15 @@ export function createBlockRefMiddleware({
 
     // perform child request
     log('Performing another request %o', childRequest);
-    const childRes: PendingJsonRpcResponse<Block> = await pify(
-      provider.sendAsync,
-    ).call(provider, childRequest);
     // copy child response onto original response
-    res.result = childRes.result;
-    res.error = childRes.error;
+    try {
+      const childResult = await provider.request<JsonRpcParams, Block>(
+        childRequest,
+      );
+      res.result = childResult;
+    } catch (error: any) {
+      res.error = error;
+    }
 
     return undefined;
   });

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -2,6 +2,7 @@ import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
+import { serializeError } from '@metamask/rpc-errors';
 import type { Json, JsonRpcParams } from '@metamask/utils';
 import { klona } from 'klona/full';
 
@@ -69,10 +70,8 @@ export function createBlockRefMiddleware({
         childRequest,
       );
       res.result = childResult;
-      res.error = undefined;
-    } catch (error: any) {
-      res.result = undefined;
-      res.error = error;
+    } catch (error) {
+      res.error = serializeError(error);
     }
 
     return undefined;

--- a/src/block-ref.ts
+++ b/src/block-ref.ts
@@ -69,7 +69,9 @@ export function createBlockRefMiddleware({
         childRequest,
       );
       res.result = childResult;
+      res.error = undefined;
     } catch (error: any) {
+      res.result = undefined;
       res.error = error;
     }
 

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -17,7 +17,11 @@ export function providerAsMiddleware(
         end();
       })
       .catch((error) => {
-        end(error);
+        if (error instanceof Error) {
+          end(error);
+        } else {
+          end();
+        }
       });
   };
 }

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -10,19 +10,15 @@ export function providerAsMiddleware(
   provider: SafeEventEmitterProvider,
 ): JsonRpcMiddleware<JsonRpcParams, Json> {
   return (req, res, _next, end) => {
-    // send request to provider
-    provider.sendAsync(
-      req,
-      (err: unknown, providerRes: PendingJsonRpcResponse<any>) => {
-        // forward any error
-        if (err instanceof Error) {
-          return end(err);
-        }
-        // copy provider response onto original response
-        Object.assign(res, providerRes);
-        return end();
-      },
-    );
+    provider
+      .request(req)
+      .then((result) => {
+        res.result = result;
+        end();
+      })
+      .catch((error) => {
+        end(error);
+      });
   };
 }
 

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -1,5 +1,8 @@
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
-import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
+import {
+  createAsyncMiddleware,
+  type JsonRpcMiddleware,
+} from '@metamask/json-rpc-engine';
 import type {
   Json,
   JsonRpcParams,
@@ -9,17 +12,9 @@ import type {
 export function providerAsMiddleware(
   provider: SafeEventEmitterProvider,
 ): JsonRpcMiddleware<JsonRpcParams, Json> {
-  return (req, res, _next, end) => {
-    provider
-      .request(req)
-      .then((result) => {
-        res.result = result;
-        end();
-      })
-      .catch((error) => {
-        end(error);
-      });
-  };
+  return createAsyncMiddleware(async (req, res) => {
+    res.result = await provider.request(req);
+  });
 }
 
 export function ethersProviderAsMiddleware(

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -17,11 +17,7 @@ export function providerAsMiddleware(
         end();
       })
       .catch((error) => {
-        if (error instanceof Error) {
-          end(error);
-        } else {
-          end();
-        }
+        end(error);
       });
   };
 }

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -147,7 +147,7 @@ describe('createRetryOnEmptyMiddleware', () => {
                 stubRequestThatFailsThenFinallySucceeds({
                   request,
                   numberOfTimesToFail: 9,
-                  successfulResponse: () => 'something',
+                  successfulResponse: async () => Promise.resolve('something'),
                 }),
               ]);
 
@@ -158,7 +158,12 @@ describe('createRetryOnEmptyMiddleware', () => {
                 numberOfTimes: 10,
               });
 
-              expect(await promiseForResponse).toBe('something');
+              expect(await promiseForResponse).toStrictEqual({
+                id: 1,
+                jsonrpc: '2.0',
+                result: 'something',
+                error: undefined,
+              });
             },
           );
         });
@@ -247,7 +252,7 @@ describe('createRetryOnEmptyMiddleware', () => {
                 buildStubForBlockNumberRequest(blockNumber),
                 stubGenericRequest({
                   request,
-                  response: () => 'success',
+                  response: async () => Promise.resolve('success'),
                 }),
               ]);
 
@@ -728,12 +733,12 @@ function stubRequestThatFailsThenFinallySucceeds<
 }): ProviderRequestStub<T, U> {
   return stubGenericRequest({
     request,
-    response: (callNumber) => {
+    response: async (callNumber) => {
       if (callNumber <= numberOfTimesToFail) {
         throw new JsonRpcError(-1, 'oops');
       }
 
-      return successfulResponse(callNumber);
+      return await successfulResponse(callNumber);
     },
     remainAfterUse: true,
   });

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -158,12 +158,7 @@ describe('createRetryOnEmptyMiddleware', () => {
                 numberOfTimes: 10,
               });
 
-              expect(await promiseForResponse).toStrictEqual({
-                id: 1,
-                jsonrpc: '2.0',
-                result: 'something',
-                error: undefined,
-              });
+              expect(await promiseForResponse).toBe('something');
             },
           );
         });

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -162,7 +162,6 @@ describe('createRetryOnEmptyMiddleware', () => {
                 id: 1,
                 jsonrpc: '2.0',
                 result: 'something',
-                error: undefined,
               });
             },
           );

--- a/src/retryOnEmpty.test.ts
+++ b/src/retryOnEmpty.test.ts
@@ -147,7 +147,7 @@ describe('createRetryOnEmptyMiddleware', () => {
                 stubRequestThatFailsThenFinallySucceeds({
                   request,
                   numberOfTimesToFail: 9,
-                  successfulResponse: async () => Promise.resolve('something'),
+                  successfulResponse: async () => 'something',
                 }),
               ]);
 
@@ -252,7 +252,7 @@ describe('createRetryOnEmptyMiddleware', () => {
                 buildStubForBlockNumberRequest(blockNumber),
                 stubGenericRequest({
                   request,
-                  response: async () => Promise.resolve('success'),
+                  response: async () => 'success',
                 }),
               ]);
 

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -115,13 +115,12 @@ export function createRetryOnEmptyMiddleware({
         }
         return result;
       });
-      log(
-        'Copying result %o and error %o',
-        childResponse.result,
-        childResponse.error,
-      );
-      res.result = childResponse.result;
+      log('Copying result %o', childResponse.result);
+      res.result = childResponse;
+      res.error = undefined;
     } catch (error: any) {
+      log('Copying error %o', error);
+      res.result = undefined;
       res.error = error;
     }
     return undefined;

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -122,10 +122,10 @@ export function createRetryOnEmptyMiddleware({
   });
 }
 
-async function retry<Response>(
+async function retry<Result>(
   maxRetries: number,
-  asyncFn: () => Promise<Response>,
-): Promise<Response> {
+  asyncFn: () => Promise<Result>,
+): Promise<Result> {
   for (let index = 0; index < maxRetries; index++) {
     try {
       return await asyncFn();

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -99,7 +99,7 @@ export function createRetryOnEmptyMiddleware({
     const childRequest = klona(req);
     // attempt child request until non-empty response is received
     try {
-      const childResponse = await retry(10, async () => {
+      const childResult = await retry(10, async () => {
         log('Performing request %o', childRequest);
         const result = await provider.request<JsonRpcParams, Block>(
           childRequest,
@@ -115,8 +115,8 @@ export function createRetryOnEmptyMiddleware({
         }
         return result;
       });
-      log('Copying result %o', childResponse.result);
-      res.result = childResponse;
+      log('Copying result %o', childResult);
+      res.result = childResult;
       res.error = undefined;
     } catch (error: any) {
       log('Copying error %o', error);

--- a/src/retryOnEmpty.ts
+++ b/src/retryOnEmpty.ts
@@ -2,7 +2,7 @@ import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import type { SafeEventEmitterProvider } from '@metamask/eth-json-rpc-provider';
 import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
-import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
+import type { Json, JsonRpcParams } from '@metamask/utils';
 import { klona } from 'klona/full';
 
 import { projectLogger, createModuleLogger } from './logging-utils';

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -139,7 +139,7 @@ export function buildStubForBlockNumberRequest(
       method: 'eth_blockNumber',
       params: [],
     },
-    response: async () => Promise.resolve(blockNumber),
+    response: async () => blockNumber,
   };
 }
 
@@ -221,7 +221,7 @@ export function stubProviderRequests(
         remainingStubs.splice(stubIndex, 1);
       }
 
-      return Promise.resolve(res);
+      return res;
     }
   });
 }

--- a/test/util/helpers.ts
+++ b/test/util/helpers.ts
@@ -28,7 +28,7 @@ export interface ProviderRequestStub<
   Result extends Json,
 > {
   request: Partial<JsonRpcRequest<Params>>;
-  response: (callNumber: number) => Result;
+  response: (callNumber: number) => Promise<Result>;
   remainAfterUse?: boolean;
 }
 
@@ -139,7 +139,7 @@ export function buildStubForBlockNumberRequest(
       method: 'eth_blockNumber',
       params: [],
     },
-    response: () => blockNumber,
+    response: async () => Promise.resolve(blockNumber),
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -987,18 +987,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-json-rpc-provider@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/eth-json-rpc-provider@npm:4.0.0"
-  dependencies:
-    "@metamask/json-rpc-engine": ^9.0.0
-    "@metamask/safe-event-emitter": ^3.0.0
-    "@metamask/utils": ^8.3.0
-  checksum: 4f8ad6a1737d54aeb83c5a1c7073a5cb17223e9cdacb0da4549aac7b57704b8239d9670c438eadf7974fe1167e59a9c54e6c32cce44b111c6514aae71429d6dd
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-json-rpc-provider@npm:^4.1.0":
+"@metamask/eth-json-rpc-provider@npm:^4.0.0, @metamask/eth-json-rpc-provider@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/eth-json-rpc-provider@npm:4.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,16 +928,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@metamask/eth-block-tracker@npm:10.0.0"
+"@metamask/eth-block-tracker@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "@metamask/eth-block-tracker@npm:10.1.0"
   dependencies:
-    "@metamask/eth-json-rpc-provider": ^4.0.0
+    "@metamask/eth-json-rpc-provider": ^4.1.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
     json-rpc-random-id: ^1.0.1
     pify: ^5.0.0
-  checksum: 3b897a41305debe9828d6d18e079289f05e07f99d829f7425ce8703b16d00f3fcd1f108b34f946dee892400e30f4fe87d8fad66311ba8b46c39258ad875f83a6
+  checksum: 9fb7deeb177c6989481f5e7c11015c274c5b43eec43fc05a5a02f284f805d06887d429c6568cdec4fac1c0c51a5f7e6814b9413cc0d7eef46d993ad10dbe696a
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/eth-block-tracker": ^10.0.0
+    "@metamask/eth-block-tracker": ^10.1.0
     "@metamask/eth-json-rpc-provider": ^4.1.0
     "@metamask/eth-sig-util": ^7.0.0
     "@metamask/json-rpc-engine": ^9.0.0
@@ -987,7 +987,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-json-rpc-provider@npm:^4.0.0, @metamask/eth-json-rpc-provider@npm:^4.1.0":
+"@metamask/eth-json-rpc-provider@npm:^4.1.0":
   version: 4.1.0
   resolution: "@metamask/eth-json-rpc-provider@npm:4.1.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,16 +928,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-block-tracker@npm:^10.1.0":
-  version: 10.1.0
-  resolution: "@metamask/eth-block-tracker@npm:10.1.0"
+"@metamask/eth-block-tracker@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "@metamask/eth-block-tracker@npm:11.0.0"
   dependencies:
     "@metamask/eth-json-rpc-provider": ^4.1.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
     json-rpc-random-id: ^1.0.1
     pify: ^5.0.0
-  checksum: 9fb7deeb177c6989481f5e7c11015c274c5b43eec43fc05a5a02f284f805d06887d429c6568cdec4fac1c0c51a5f7e6814b9413cc0d7eef46d993ad10dbe696a
+  checksum: 27a2622cda97626c80119629108f739aa745b0c704649e00f6841aac10410f23c00ab7feb272539ccf209f092648b1538aa87c1247185ced01c2993b68fb8db5
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
     "@metamask/eslint-config-jest": ^12.1.0
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
-    "@metamask/eth-block-tracker": ^10.1.0
+    "@metamask/eth-block-tracker": ^11.0.0
     "@metamask/eth-json-rpc-provider": ^4.1.0
     "@metamask/eth-sig-util": ^7.0.0
     "@metamask/json-rpc-engine": ^9.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,7 +953,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^12.1.0
     "@metamask/eslint-config-typescript": ^12.1.0
     "@metamask/eth-block-tracker": ^10.0.0
-    "@metamask/eth-json-rpc-provider": ^4.0.0
+    "@metamask/eth-json-rpc-provider": ^4.1.0
     "@metamask/eth-sig-util": ^7.0.0
     "@metamask/json-rpc-engine": ^9.0.0
     "@metamask/rpc-errors": ^6.0.0
@@ -995,6 +995,19 @@ __metadata:
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.3.0
   checksum: 4f8ad6a1737d54aeb83c5a1c7073a5cb17223e9cdacb0da4549aac7b57704b8239d9670c438eadf7974fe1167e59a9c54e6c32cce44b111c6514aae71429d6dd
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-provider@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@metamask/eth-json-rpc-provider@npm:4.1.0"
+  dependencies:
+    "@metamask/json-rpc-engine": ^9.0.0
+    "@metamask/rpc-errors": ^6.2.1
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.3.0
+    uuid: ^8.3.2
+  checksum: c9669c93df073423d36ff941b512247b569e7f7c56cc6110565bc8dc6590ad691a78d6d17eea6243721c1c464f0f008ea1326fc7373f90fb705fba5fb85d804d
   languageName: node
   linkType: hard
 
@@ -6901,6 +6914,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
After [`SafeEventEmitterProvider` is updated to support EIP-1193](https://github.com/MetaMask/core/issues/4095) and a new version of `@metamask/eth-json-rpc-provider` is released, we should adapt to the changes:

- We should bump `@metamask/eth-json-rpc-provider` to rely on the new changes.
- At that point, calling `sendAsync` will be deprecated; we should use `request` instead.
  - There are two middleware which use `sendAsync`: `retryOnEmpty` and `block-ref`.
  - We also use `sendAsync` in `providerAsMiddleware`.
  - Finally, there are a lot of tests that mock `sendAsync` on the provider. The tests use a helper, `stubProviderRequests` which does this in particular. These references need to be changed. 

* Fixes [#299](https://github.com/MetaMask/eth-json-rpc-middleware/issues/299)