### PR TITLE
Remove support for `eth_sign`

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -54,10 +54,6 @@ export interface WalletMiddlewareOptions {
     address: string,
     req: JsonRpcRequest,
   ) => Promise<string>;
-  processEthSignMessage?: (
-    msgParams: MessageParams,
-    req: JsonRpcRequest,
-  ) => Promise<string>;
   processPersonalMessage?: (
     msgParams: MessageParams,
     req: JsonRpcRequest,
@@ -91,7 +87,6 @@ export function createWalletMiddleware({
   getAccounts,
   processDecryptMessage,
   processEncryptionPublicKey,
-  processEthSignMessage,
   processPersonalMessage,
   processTransaction,
   processSignTransaction,
@@ -112,7 +107,6 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
     eth_sendTransaction: createAsyncMiddleware(sendTransaction),
     eth_signTransaction: createAsyncMiddleware(signTransaction),
     // message signatures
-    eth_sign: createAsyncMiddleware(ethSign),
     eth_signTypedData: createAsyncMiddleware(signTypedData),
     eth_signTypedData_v3: createAsyncMiddleware(signTypedDataV3),
     eth_signTypedData_v4: createAsyncMiddleware(signTypedDataV4),
@@ -194,36 +188,6 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
   //
   // message signatures
   //
-
-  async function ethSign(
-    req: JsonRpcRequest,
-    res: PendingJsonRpcResponse<Json>,
-  ): Promise<void> {
-    if (!processEthSignMessage) {
-      throw rpcErrors.methodNotSupported();
-    }
-    if (
-      !req?.params ||
-      !Array.isArray(req.params) ||
-      !(req.params.length >= 2)
-    ) {
-      throw rpcErrors.invalidInput();
-    }
-
-    const params = req.params as [string, string, Record<string, string>?];
-    const address: string = await validateAndNormalizeKeyholder(params[0], req);
-    const message = params[1];
-    const extraParams = params[2] || {};
-    const msgParams: MessageParams = {
-      ...extraParams,
-      from: address,
-      data: message,
-      signatureMethod: 'eth_sign',
-    };
-
-    res.result = await processEthSignMessage(msgParams, req);
-  }
-
   async function signTypedData(
     req: JsonRpcRequest,
     res: PendingJsonRpcResponse<Json>,


### PR DESCRIPTION
## Explanation
Months ago, because of phishing risk, we disabled the `eth_sign` API method by default (users could manually enable it with a preference toggle). Now because of additional risk associated with [potentially malicious EIP-3074 invokers](https://ethereum-magicians.org/t/eip-3074-is-unsafe-unnecessary-puts-user-funds-at-risk-while-fragmenting-ux-liquidity-and-the-wallet-stack/19662) we are fully removing support for this method.

## References

Related: https://github.com/MetaMask/MetaMask-planning/issues/2371

Extension PR: https://github.com/MetaMask/metamask-extension/pull/24756

## Changelog

## Removed
- **BREAKING:** Middleware for `eth_sign` method is removed
 - `createWalletMiddleware` no longer accepts `processEthSignMessage` as an option
