### PR TITLE
Temporarily use Node 22.5.1 to get CI to run

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.5.1]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.5.1]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -80,7 +80,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.5.1]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
There seems to be a regression in Node 22.5.0 which [prevents `yarn install` from running][1] and in turns prevents CI from completing successfully. This regression was [fixed in 22.5.1][2]. We are using `22.x` in CI, so in theory it should be using this version, but that does not seem be the case right now. So this commit ensures that CI is using this version by naming it explicitly.

[1]: https://github.com/yarnpkg/berry/issues/6398
[2]: https://github.com/nodejs/node/pull/53935