### PR TITLE
fix: restore pipeline node version to 22.x

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.5.1]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +49,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.5.1]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -80,7 +80,7 @@ jobs:
       - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.5.1]
+        node-version: [18.x, 20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
This PR Restore the pipeline node version to `22.x`. This fix follows the temporary solution implemented in [PR #321](https://github.com/MetaMask/eth-json-rpc-middleware/pull/321), which set the version to `22.5.1`. The temporary fix is no longer needed because the merge of [PR node-versions/#182](https://github.com/actions/node-versions/pull/182) now automatically uses the same version.