### PR TITLE
Request validation should not throw if verifyingContract is not defined in typed signature

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -499,10 +499,8 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  * @param data - The data passed in typedSign request.
  */
 function validateVerifyingContract(data: string) {
-  const {
-    domain: { verifyingContract },
-  } = parseTypedMessage(data);
-  if (!isValidHexAddress(verifyingContract)) {
+  const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
+  if (verifyingContract && !isValidHexAddress(verifyingContract)) {
     throw rpcErrors.invalidInput();
   }
 }


### PR DESCRIPTION
Creating PR https://github.com/MetaMask/eth-json-rpc-middleware/pull/328 against `14.x` branch to expedite release of bug fix.