### PR TITLE
[14.x] fix: support ethermint's EIP712 implementation

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -478,6 +478,51 @@ describe('wallet', () => {
     });
   });
 
+  it('should not throw if verifyingContract is "cosmos"', async () => {
+    const { engine } = createTestSetup();
+    const getAccounts = async () => testAddresses.slice();
+    const witnessedMsgParams: TypedMessageParams[] = [];
+    const processTypedMessageV3 = async (msgParams: TypedMessageParams) => {
+      witnessedMsgParams.push(msgParams);
+      // Assume testMsgSig is the expected signature result
+      return testMsgSig;
+    };
+
+    engine.push(createWalletMiddleware({ getAccounts, processTypedMessageV3 }));
+
+    const message = {
+      types: {
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+      },
+      primaryType: 'EIP712Domain',
+      message: {},
+      domain: {
+        verifyingContract: 'cosmos',
+      },
+    };
+
+    const stringifiedMessage = JSON.stringify(message);
+
+    const payload = {
+      method: 'eth_signTypedData_v3',
+      params: [testAddresses[0], stringifiedMessage], // Assuming testAddresses[0] is a valid address from your setup
+    };
+
+    const promise = pify(engine.handle).call(engine, payload);
+    const result = await promise;
+    expect(result).toStrictEqual({
+      id: undefined,
+      jsonrpc: undefined,
+      result:
+        '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
+    });
+  });
+
   describe('signTypedDataV4', () => {
     const getMsgParams = (verifyingContract?: string) => ({
       types: {

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -642,6 +642,35 @@ describe('wallet', () => {
           '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
       });
     });
+
+    it('should not throw if request is permit with verifyingContract address equal to "cosmos"', async () => {
+      const { engine } = createTestSetup();
+      const getAccounts = async () => testAddresses.slice();
+      const witnessedMsgParams: TypedMessageParams[] = [];
+      const processTypedMessageV4 = async (msgParams: TypedMessageParams) => {
+        witnessedMsgParams.push(msgParams);
+        // Assume testMsgSig is the expected signature result
+        return testMsgSig;
+      };
+
+      engine.push(
+        createWalletMiddleware({ getAccounts, processTypedMessageV4 }),
+      );
+
+      const payload = {
+        method: 'eth_signTypedData_v4',
+        params: [testAddresses[0], JSON.stringify(getMsgParams('cosmos'))],
+      };
+
+      const promise = pify(engine.handle).call(engine, payload);
+      const result = await promise;
+      expect(result).toStrictEqual({
+        id: undefined,
+        jsonrpc: undefined,
+        result:
+          '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
+      });
+    });
   });
 
   describe('sign', () => {

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -478,51 +478,6 @@ describe('wallet', () => {
     });
   });
 
-  it('should not throw if verifyingContract is "cosmos"', async () => {
-    const { engine } = createTestSetup();
-    const getAccounts = async () => testAddresses.slice();
-    const witnessedMsgParams: TypedMessageParams[] = [];
-    const processTypedMessageV3 = async (msgParams: TypedMessageParams) => {
-      witnessedMsgParams.push(msgParams);
-      // Assume testMsgSig is the expected signature result
-      return testMsgSig;
-    };
-
-    engine.push(createWalletMiddleware({ getAccounts, processTypedMessageV3 }));
-
-    const message = {
-      types: {
-        EIP712Domain: [
-          { name: 'name', type: 'string' },
-          { name: 'version', type: 'string' },
-          { name: 'chainId', type: 'uint256' },
-          { name: 'verifyingContract', type: 'address' },
-        ],
-      },
-      primaryType: 'EIP712Domain',
-      message: {},
-      domain: {
-        verifyingContract: 'cosmos',
-      },
-    };
-
-    const stringifiedMessage = JSON.stringify(message);
-
-    const payload = {
-      method: 'eth_signTypedData_v3',
-      params: [testAddresses[0], stringifiedMessage], // Assuming testAddresses[0] is a valid address from your setup
-    };
-
-    const promise = pify(engine.handle).call(engine, payload);
-    const result = await promise;
-    expect(result).toStrictEqual({
-      id: undefined,
-      jsonrpc: undefined,
-      result:
-        '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
-    });
-  });
-
   describe('signTypedDataV4', () => {
     const getMsgParams = (verifyingContract?: string) => ({
       types: {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -506,10 +506,8 @@ function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
   if (
     verifyingContract &&
-    !(
-      isValidHexAddress(verifyingContract) ||
-      (verifyingContract as any) === 'cosmos'
-    )
+    !isValidHexAddress(verifyingContract) &&
+    (verifyingContract as any) !== 'cosmos'
   ) {
     throw rpcErrors.invalidInput();
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -504,10 +504,12 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  */
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
+  // Explicit check for cosmos here has been added to address this issue
+  // https://github.com/MetaMask/eth-json-rpc-middleware/issues/new
   if (
     verifyingContract &&
-    !isValidHexAddress(verifyingContract) &&
-    (verifyingContract as any) !== 'cosmos'
+    (verifyingContract as string) !== 'cosmos' &&
+    !isValidHexAddress(verifyingContract)
   ) {
     throw rpcErrors.invalidInput();
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -500,7 +500,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  */
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
-  if (verifyingContract && !isValidHexAddress(verifyingContract)) {
+  if (verifyingContract && !(isValidHexAddress(verifyingContract) || verifyingContract == 'cosmos')) {
     throw rpcErrors.invalidInput();
   }
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -497,10 +497,20 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  * Validates verifyingContract of typedSignMessage.
  *
  * @param data - The data passed in typedSign request.
+ * This function allows the verifyingContract to be either:
+ * - A valid hex address
+ * - The string "cosmos" (as it is hard-coded in some Cosmos ecosystem's EVM adapters)
+ * - An empty string
  */
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
-  if (verifyingContract && !(isValidHexAddress(verifyingContract) || verifyingContract == 'cosmos')) {
+  if (
+    verifyingContract &&
+    !(
+      isValidHexAddress(verifyingContract) ||
+      (verifyingContract as any) === 'cosmos'
+    )
+  ) {
     throw rpcErrors.invalidInput();
   }
 }


### PR DESCRIPTION
MM is broken since v12.1.1 for cosmos chains that use `https://github.com/evmos/ethermint` as EVM adapter.

`Ethermint` uses hard coded `"cosmos"` string as the `VerifyingContract` field, which is broken since `validateVerifyingContract` was introduced in MM.

This PR adds support to allow "cosmos" as the `VerifyingContract` value.