### PR TITLE
fix: change types signatures verifyingContract validation to allow 'cosmos' as address

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -597,6 +597,35 @@ describe('wallet', () => {
           '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
       });
     });
+
+    it('should not throw if request is permit with verifyingContract address equal to "cosmos"', async () => {
+      const { engine } = createTestSetup();
+      const getAccounts = async () => testAddresses.slice();
+      const witnessedMsgParams: TypedMessageParams[] = [];
+      const processTypedMessageV4 = async (msgParams: TypedMessageParams) => {
+        witnessedMsgParams.push(msgParams);
+        // Assume testMsgSig is the expected signature result
+        return testMsgSig;
+      };
+
+      engine.push(
+        createWalletMiddleware({ getAccounts, processTypedMessageV4 }),
+      );
+
+      const payload = {
+        method: 'eth_signTypedData_v4',
+        params: [testAddresses[0], JSON.stringify(getMsgParams('cosmos'))],
+      };
+
+      const promise = pify(engine.handle).call(engine, payload);
+      const result = await promise;
+      expect(result).toStrictEqual({
+        id: undefined,
+        jsonrpc: undefined,
+        result:
+          '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
+      });
+    });
   });
 
   describe('sign', () => {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -465,7 +465,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
   // Explicit check for cosmos here has been added to address this issue
-  // https://github.com/MetaMask/metamask-extension/issues/26980
+  // https://github.com/MetaMask/eth-json-rpc-middleware/issues/new
   if (
     verifyingContract &&
     (verifyingContract as string) !== 'cosmos' &&

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -464,7 +464,13 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
  */
 function validateVerifyingContract(data: string) {
   const { domain: { verifyingContract } = {} } = parseTypedMessage(data);
-  if (verifyingContract && !isValidHexAddress(verifyingContract)) {
+  // Explicit check for cosmos here has been added to address this issue
+  // https://github.com/MetaMask/metamask-extension/issues/26980
+  if (
+    verifyingContract &&
+    (verifyingContract as string) !== 'cosmos' &&
+    !isValidHexAddress(verifyingContract)
+  ) {
     throw rpcErrors.invalidInput();
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/27070

Following the discussion in the thread, I am moving this validation to middleware. https://consensys.slack.com/archives/C02GENU377A/p1725914308614879

Original issue which got a hotfix: https://github.com/MetaMask/metamask-extension/issues/26980