### PR TITLE
Update fetch middleware to preserve original error data

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -130,9 +130,7 @@ function parseResponse(fetchRes: Response, body: Record<string, Block>): Block {
 
   // check for rpc error
   if (body.error) {
-    throw rpcErrors.internal({
-      data: body.error,
-    });
+    throw rpcErrors.internal(body.error);
   }
   // return successful result
   return body.result;


### PR DESCRIPTION
Recently the rpc-errors package had been updated to preserve the original RPC error message (https://github.com/MetaMask/rpc-errors/pull/160). However, the fetch middleware in this package has been preventing this as it has not been forwarding the `body.error.message` string from the response, instead rewriting all errors with the default 'Internal JSON-RPC error.'. This PR addresses that. 

The data could also be passed explicitly as `rpcErrors.internal({ message: body.error.message, data: body.error.data })` but the approach of passing the whole `body.error` has the advantage of `parseOpts` in `getJsonRpcError` handling the case in which if `body.error` is not an object but a string. 

I wanted to add tests to cover this, but the only way I see this being done is by exporting the `parseResponse` method. Let me know if this is something you'd like covered. 