### PR TITLE
fix: Add validation for types sign message primary type

### DIFF
--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -4,11 +4,11 @@ describe('CommonUtils', () => {
   describe('stripArrayTypeIfPresent', () => {
     it('remove array brackets from the type if present', () => {
       expect(stripArrayTypeIfPresent('string[]')).toBe('string');
-      expect(stripArrayTypeIfPresent('string []')).toBe('string');
     });
 
     it('return types which are not array without any change', () => {
       expect(stripArrayTypeIfPresent('string')).toBe('string');
+      expect(stripArrayTypeIfPresent('string []')).toBe('string []');
     });
   });
 });

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -4,6 +4,7 @@ describe('CommonUtils', () => {
   describe('stripArrayTypeIfPresent', () => {
     it('remove array brackets from the type if present', () => {
       expect(stripArrayTypeIfPresent('string[]')).toBe('string');
+      expect(stripArrayTypeIfPresent('string[5]')).toBe('string');
     });
 
     it('return types which are not array without any change', () => {

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -4,6 +4,7 @@ describe('CommonUtils', () => {
   describe('stripArrayTypeIfPresent', () => {
     it('remove array brackets from the type if present', () => {
       expect(stripArrayTypeIfPresent('string[]')).toBe('string');
+      expect(stripArrayTypeIfPresent('string []')).toBe('string');
     });
 
     it('return types which are not array without any change', () => {

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -1,0 +1,13 @@
+import { stripArrayTypeIfPresent } from './common';
+
+describe('CommonUtils', () => {
+  describe('stripArrayTypeIfPresent', () => {
+    it('remove array brackets from the type if present', () => {
+      expect(stripArrayTypeIfPresent('string[]')).toBe('string');
+    });
+
+    it('return types which are not array without any change', () => {
+      expect(stripArrayTypeIfPresent('string')).toBe('string');
+    });
+  });
+});

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,8 +5,8 @@
  * @returns Parameter string with array brackets [] removed.
  */
 export const stripArrayTypeIfPresent = (typeString: string) => {
-  if (typeString?.match(/\S\s*\[\]$/u) !== null) {
-    return typeString.replace(/\s*\[\]$/gu, '').trim();
+  if (typeString?.match(/\S\[\]$/u) !== null) {
+    return typeString.replace(/\[\]$/gu, '').trim();
   }
   return typeString;
 };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,0 +1,6 @@
+export const stripArrayTypeIfPresent = (typeString: string) => {
+  if(typeString && typeString.match(/\S\[\]$/u) !== null) {
+    return typeString.replace(/\[\]$/gu, '').trim();
+  }
+  return typeString;
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,12 @@
+/**
+ * Function to stripe array brackets if string defining the type has it.
+ *
+ * @param typeString - String defining type from which array brackets are required to be removed.
+ * @returns Parameter string with array brackets [] removed.
+ */
 export const stripArrayTypeIfPresent = (typeString: string) => {
-  if (typeString && typeString.match(/\S\[\]$/u) !== null) {
-    return typeString.replace(/\[\]$/gu, '').trim();
+  if (typeString?.match(/\S\s*\[\]$/u) !== null) {
+    return typeString.replace(/\s*\[\]$/gu, '').trim();
   }
   return typeString;
 };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,8 +5,8 @@
  * @returns Parameter string with array brackets [] removed.
  */
 export const stripArrayTypeIfPresent = (typeString: string) => {
-  if (typeString?.match(/\S\[\]$/u) !== null) {
-    return typeString.replace(/\[\]$/gu, '').trim();
+  if (typeString?.match(/\S\[\d*\]$/u) !== null) {
+    return typeString.replace(/\[\d*\]$/gu, '').trim();
   }
   return typeString;
 };

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,6 +1,6 @@
 export const stripArrayTypeIfPresent = (typeString: string) => {
-  if(typeString && typeString.match(/\S\[\]$/u) !== null) {
+  if (typeString && typeString.match(/\S\[\]$/u) !== null) {
     return typeString.replace(/\[\]$/gu, '').trim();
   }
   return typeString;
-}
+};

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -646,7 +646,7 @@ describe('wallet', () => {
         method: 'eth_signTypedData_v4',
         params: [
           testAddresses[0],
-          JSON.stringify({...messageParams, types: undefined}),
+          JSON.stringify({ ...messageParams, types: undefined }),
         ],
       };
 
@@ -673,7 +673,10 @@ describe('wallet', () => {
         method: 'eth_signTypedData_v4',
         params: [
           testAddresses[0],
-          JSON.stringify({...messageParams, types: {...messageParams.types, Permit: undefined}}),
+          JSON.stringify({
+            ...messageParams,
+            types: { ...messageParams.types, Permit: undefined },
+          }),
         ],
       };
 

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -626,6 +626,60 @@ describe('wallet', () => {
           '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
       });
     });
+
+    it('should throw if message does not have types defined', async () => {
+      const { engine } = createTestSetup();
+      const getAccounts = async () => testAddresses.slice();
+      const witnessedMsgParams: TypedMessageParams[] = [];
+      const processTypedMessageV4 = async (msgParams: TypedMessageParams) => {
+        witnessedMsgParams.push(msgParams);
+        // Assume testMsgSig is the expected signature result
+        return testMsgSig;
+      };
+
+      engine.push(
+        createWalletMiddleware({ getAccounts, processTypedMessageV4 }),
+      );
+
+      const messageParams = getMsgParams();
+      const payload = {
+        method: 'eth_signTypedData_v4',
+        params: [
+          testAddresses[0],
+          JSON.stringify({...messageParams, types: undefined}),
+        ],
+      };
+
+      const promise = pify(engine.handle).call(engine, payload);
+      await expect(promise).rejects.toThrow('Invalid input.');
+    });
+
+    it('should throw if type of primaryType is not defined', async () => {
+      const { engine } = createTestSetup();
+      const getAccounts = async () => testAddresses.slice();
+      const witnessedMsgParams: TypedMessageParams[] = [];
+      const processTypedMessageV4 = async (msgParams: TypedMessageParams) => {
+        witnessedMsgParams.push(msgParams);
+        // Assume testMsgSig is the expected signature result
+        return testMsgSig;
+      };
+
+      engine.push(
+        createWalletMiddleware({ getAccounts, processTypedMessageV4 }),
+      );
+
+      const messageParams = getMsgParams();
+      const payload = {
+        method: 'eth_signTypedData_v4',
+        params: [
+          testAddresses[0],
+          JSON.stringify({...messageParams, types: {...messageParams.types, Permit: undefined}}),
+        ],
+      };
+
+      const promise = pify(engine.handle).call(engine, payload);
+      await expect(promise).rejects.toThrow('Invalid input.');
+    });
   });
 
   describe('sign', () => {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -472,7 +472,7 @@ function validatePrimaryType(data: string) {
   }
 
   // Primary type can be an array.
-  const baseType = stripArrayTypeIfPresent(primaryType)
+  const baseType = stripArrayTypeIfPresent(primaryType);
 
   // Return if the base type is not defined in the types
   const baseTypeDefinitions = types[baseType];

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -13,6 +13,7 @@ import {
 } from '@metamask/utils';
 
 import type { Block } from './types';
+import { stripArrayTypeIfPresent } from './utils/common';
 import { normalizeTypedMessage, parseTypedMessage } from './utils/normalize';
 
 /*
@@ -243,6 +244,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
 
     const address = await validateAndNormalizeKeyholder(params[0], req);
     const message = normalizeTypedMessage(params[1]);
+    validatePrimaryType(message);
     validateVerifyingContract(message);
     const version = 'V3';
     const msgParams: TypedMessageParams = {
@@ -274,6 +276,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
 
     const address = await validateAndNormalizeKeyholder(params[0], req);
     const message = normalizeTypedMessage(params[1]);
+    validatePrimaryType(message);
     validateVerifyingContract(message);
     const version = 'V4';
     const msgParams: TypedMessageParams = {
@@ -454,6 +457,27 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
     throw rpcErrors.invalidParams({
       message: `Invalid parameters: must provide an Ethereum address.`,
     });
+  }
+}
+
+/**
+ * Validates primary of typedSignMessage, to ensure that it's type definition is present in message.
+ *
+ * @param data - The data passed in typedSign request.
+ */
+function validatePrimaryType(data: string) {
+  const { primaryType, types } = parseTypedMessage(data);
+  if (!types) {
+    throw rpcErrors.invalidInput();
+  }
+
+  // Primary type can be an array.
+  const baseType = stripArrayTypeIfPresent(primaryType)
+
+  // Return if the base type is not defined in the types
+  const baseTypeDefinitions = types[baseType];
+  if (!baseTypeDefinitions) {
+    throw rpcErrors.invalidInput();
   }
 }
 


### PR DESCRIPTION
Ref: https://github.com/MetaMask/metamask-extension/issues/22899

Throw error if typed sign request does not have primary type defined.