### PR TITLE
fix: regex match condition for primary type

### DIFF
--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -10,6 +10,7 @@ describe('CommonUtils', () => {
     it('return types which are not array without any change', () => {
       expect(stripArrayTypeIfPresent('string')).toBe('string');
       expect(stripArrayTypeIfPresent('string []')).toBe('string []');
+      expect(stripArrayTypeIfPresent(undefined as unknown as string)).toBe(undefined);
     });
   });
 });

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -10,7 +10,9 @@ describe('CommonUtils', () => {
     it('return types which are not array without any change', () => {
       expect(stripArrayTypeIfPresent('string')).toBe('string');
       expect(stripArrayTypeIfPresent('string []')).toBe('string []');
-      expect(stripArrayTypeIfPresent(undefined as unknown as string)).toBeUndefined();
+      expect(
+        stripArrayTypeIfPresent(undefined as unknown as string),
+      ).toBeUndefined();
     });
   });
 });

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -10,7 +10,7 @@ describe('CommonUtils', () => {
     it('return types which are not array without any change', () => {
       expect(stripArrayTypeIfPresent('string')).toBe('string');
       expect(stripArrayTypeIfPresent('string []')).toBe('string []');
-      expect(stripArrayTypeIfPresent(undefined as unknown as string)).toBe(undefined);
+      expect(stripArrayTypeIfPresent(undefined as unknown as string)).toBeUndefined();
     });
   });
 });

--- a/src/utils/common.test.ts
+++ b/src/utils/common.test.ts
@@ -11,7 +11,8 @@ describe('CommonUtils', () => {
       expect(stripArrayTypeIfPresent('string')).toBe('string');
       expect(stripArrayTypeIfPresent('string []')).toBe('string []');
       expect(
-        stripArrayTypeIfPresent(undefined as unknown as string),
+        // @ts-expect-error Intentionally testing invalid input
+        stripArrayTypeIfPresent(undefined),
       ).toBeUndefined();
     });
   });

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -5,7 +5,7 @@
  * @returns Parameter string with array brackets [] removed.
  */
 export const stripArrayTypeIfPresent = (typeString: string) => {
-  if (typeString?.match(/\S\[\d*\]$/u) !== null) {
+  if (typeString?.match(/\S\[\d*\]$/u)) {
     return typeString.replace(/\[\d*\]$/gu, '').trim();
   }
   return typeString;


### PR DESCRIPTION
This PR is in continuation of the previous one: https://github.com/MetaMask/eth-json-rpc-middleware/pull/350

It fixes a condition while validating primary type of types signatures.