### PR TITLE
feat: support updated EIP-5792 specification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,9 @@ export * from './block-tracker-inspector';
 export * from './fetch';
 export * from './inflight-cache';
 export type {
+  GetCallsStatusHook,
   GetCallsStatusParams,
-  GetCallsStatusReceipt,
   GetCallsStatusResult,
-  GetTransactionReceiptsByBatchIdHook,
 } from './methods/wallet-get-calls-status';
 export type {
   GetCapabilitiesHook,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   GetCallsStatusParams,
   GetCallsStatusResult,
 } from './methods/wallet-get-calls-status';
+export { GetCallsStatusCode } from './methods/wallet-get-calls-status';
 export type {
   GetCapabilitiesHook,
   GetCapabilitiesParams,
@@ -18,6 +19,7 @@ export type {
   ProcessSendCallsHook,
   SendCalls,
   SendCallsParams,
+  SendCallsResult,
 } from './methods/wallet-send-calls';
 export * from './providerAsMiddleware';
 export * from './retryOnEmpty';

--- a/src/methods/wallet-get-calls-status.test.ts
+++ b/src/methods/wallet-get-calls-status.test.ts
@@ -1,14 +1,18 @@
-import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
+import type {
+  Hex,
+  JsonRpcRequest,
+  PendingJsonRpcResponse,
+} from '@metamask/utils';
 import { klona } from 'klona';
 
 import type {
+  GetCallsStatusHook,
   GetCallsStatusParams,
   GetCallsStatusResult,
-  GetTransactionReceiptsByBatchIdHook,
 } from './wallet-get-calls-status';
 import { walletGetCallsStatus } from './wallet-get-calls-status';
 
-const ID_MOCK = '1234-5678';
+const ID_MOCK = '0x12345678';
 
 const RECEIPT_MOCK = {
   logs: [
@@ -30,15 +34,23 @@ const REQUEST_MOCK = {
   params: [ID_MOCK],
 } as unknown as JsonRpcRequest<GetCallsStatusParams>;
 
+const RESULT_MOCK = {
+  version: '1.0',
+  id: ID_MOCK,
+  chainId: '0x1',
+  status: 1,
+  receipts: [RECEIPT_MOCK, RECEIPT_MOCK],
+};
+
 describe('wallet_getCallsStatus', () => {
   let request: JsonRpcRequest<GetCallsStatusParams>;
   let params: GetCallsStatusParams;
   let response: PendingJsonRpcResponse<GetCallsStatusResult>;
-  let getTransactionReceiptsByBatchIdMock: jest.MockedFunction<GetTransactionReceiptsByBatchIdHook>;
+  let getCallsStatusMock: jest.MockedFunction<GetCallsStatusHook>;
 
   async function callMethod() {
     return walletGetCallsStatus(request, response, {
-      getTransactionReceiptsByBatchId: getTransactionReceiptsByBatchIdMock,
+      getCallsStatus: getCallsStatusMock,
     });
   }
 
@@ -49,48 +61,17 @@ describe('wallet_getCallsStatus', () => {
     params = request.params as GetCallsStatusParams;
     response = {} as PendingJsonRpcResponse<GetCallsStatusResult>;
 
-    getTransactionReceiptsByBatchIdMock = jest
-      .fn()
-      .mockResolvedValue([RECEIPT_MOCK, RECEIPT_MOCK]);
+    getCallsStatusMock = jest.fn().mockResolvedValue(RESULT_MOCK);
   });
 
   it('calls hook', async () => {
     await callMethod();
-    expect(getTransactionReceiptsByBatchIdMock).toHaveBeenCalledWith(
-      params[0],
-      request,
-    );
+    expect(getCallsStatusMock).toHaveBeenCalledWith(params[0], request);
   });
 
-  it('returns confirmed status if all receipts available', async () => {
+  it('returns result from hook', async () => {
     await callMethod();
-    expect(response.result?.status).toBe('CONFIRMED');
-  });
-
-  it('returns pending status if missing receipts', async () => {
-    getTransactionReceiptsByBatchIdMock = jest
-      .fn()
-      .mockResolvedValue([RECEIPT_MOCK, undefined]);
-
-    await callMethod();
-    expect(response.result?.status).toBe('PENDING');
-    expect(response.result?.receipts).toBeNull();
-  });
-
-  it('returns receipts', async () => {
-    await callMethod();
-
-    expect(response.result?.receipts).toStrictEqual([
-      RECEIPT_MOCK,
-      RECEIPT_MOCK,
-    ]);
-  });
-
-  it('returns null if no receipts', async () => {
-    getTransactionReceiptsByBatchIdMock = jest.fn().mockResolvedValue([]);
-
-    await callMethod();
-    expect(response.result).toBeNull();
+    expect(response.result).toStrictEqual(RESULT_MOCK);
   });
 
   it('throws if no hook', async () => {
@@ -119,27 +100,23 @@ describe('wallet_getCallsStatus', () => {
           `);
   });
 
-  it('throws if empty', async () => {
-    params[0] = '';
+  it('throws if not hex', async () => {
+    params[0] = '123' as Hex;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
             [Error: Invalid params
 
-            0 - Expected a nonempty string but received an empty one]
+            0 - Expected a string matching \`/^0x[0-9a-f]+$/\` but received "123"]
           `);
   });
 
-  it('removes excess properties from receipts', async () => {
-    getTransactionReceiptsByBatchIdMock.mockResolvedValue([
-      {
-        ...RECEIPT_MOCK,
-        extra: 'value1',
-        logs: [{ ...RECEIPT_MOCK.logs[0], extra2: 'value2' }],
-      } as never,
-    ]);
+  it('throws if empty', async () => {
+    params[0] = '' as never;
 
-    await callMethod();
+    await expect(callMethod()).rejects.toMatchInlineSnapshot(`
+            [Error: Invalid params
 
-    expect(response.result?.receipts).toStrictEqual([RECEIPT_MOCK]);
+            0 - Expected a string matching \`/^0x[0-9a-f]+$/\` but received ""]
+          `);
   });
 });

--- a/src/methods/wallet-get-calls-status.test.ts
+++ b/src/methods/wallet-get-calls-status.test.ts
@@ -100,7 +100,7 @@ describe('wallet_getCallsStatus', () => {
           `);
   });
 
-  it('throws if not hex', async () => {
+  it('throws if address is not hex', async () => {
     params[0] = '123' as Hex;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
@@ -110,7 +110,7 @@ describe('wallet_getCallsStatus', () => {
           `);
   });
 
-  it('throws if empty', async () => {
+  it('throws if address is empty', async () => {
     params[0] = '' as never;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`

--- a/src/methods/wallet-get-calls-status.ts
+++ b/src/methods/wallet-get-calls-status.ts
@@ -1,85 +1,61 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Infer } from '@metamask/superstruct';
-import {
-  nonempty,
-  optional,
-  mask,
-  string,
-  array,
-  object,
-  tuple,
-} from '@metamask/superstruct';
+import { tuple } from '@metamask/superstruct';
 import type {
+  Hex,
   Json,
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import { HexChecksumAddressStruct, StrictHexStruct } from '@metamask/utils';
+import { StrictHexStruct } from '@metamask/utils';
 
 import { validateParams } from '../utils/validation';
 
-const GetCallsStatusStruct = tuple([nonempty(string())]);
-
-const GetCallsStatusReceiptStruct = object({
-  logs: optional(
-    array(
-      object({
-        address: optional(HexChecksumAddressStruct),
-        data: optional(StrictHexStruct),
-        topics: optional(array(StrictHexStruct)),
-      }),
-    ),
-  ),
-  status: optional(StrictHexStruct),
-  chainId: optional(StrictHexStruct),
-  blockHash: optional(StrictHexStruct),
-  blockNumber: optional(StrictHexStruct),
-  gasUsed: optional(StrictHexStruct),
-  transactionHash: optional(StrictHexStruct),
-});
+const GetCallsStatusStruct = tuple([StrictHexStruct]);
 
 export type GetCallsStatusParams = Infer<typeof GetCallsStatusStruct>;
-export type GetCallsStatusReceipt = Infer<typeof GetCallsStatusReceiptStruct>;
 
 export type GetCallsStatusResult = {
-  status: 'PENDING' | 'CONFIRMED';
-  receipts?: GetCallsStatusReceipt[];
+  version: string;
+  id: Hex;
+  chainId: Hex;
+  status: number;
+  receipts?: {
+    logs: {
+      address: Hex;
+      data: Hex;
+      topics: Hex[];
+    }[];
+    status: Hex;
+    blockHash: Hex;
+    blockNumber: Hex;
+    gasUsed: Hex;
+    transactionHash: Hex;
+  }[];
+  capabilities?: Record<string, Json>;
 };
 
-export type GetTransactionReceiptsByBatchIdHook = (
-  batchId: string,
+export type GetCallsStatusHook = (
+  id: GetCallsStatusParams[0],
   req: JsonRpcRequest,
-) => Promise<GetCallsStatusReceipt[]>;
+) => Promise<GetCallsStatusResult[]>;
 
 export async function walletGetCallsStatus(
   req: JsonRpcRequest,
   res: PendingJsonRpcResponse<Json>,
   {
-    getTransactionReceiptsByBatchId,
+    getCallsStatus,
   }: {
-    getTransactionReceiptsByBatchId?: GetTransactionReceiptsByBatchIdHook;
+    getCallsStatus?: GetCallsStatusHook;
   },
 ): Promise<void> {
-  if (!getTransactionReceiptsByBatchId) {
+  if (!getCallsStatus) {
     throw rpcErrors.methodNotSupported();
   }
 
   validateParams(req.params, GetCallsStatusStruct);
 
-  const batchId = req.params[0];
-  const rawReceipts = await getTransactionReceiptsByBatchId(batchId, req);
+  const id = req.params[0];
 
-  if (!rawReceipts.length) {
-    res.result = null;
-    return;
-  }
-
-  const isComplete = rawReceipts.every((receipt) => Boolean(receipt));
-  const status = isComplete ? 'CONFIRMED' : 'PENDING';
-
-  const receipts = isComplete
-    ? rawReceipts.map((receipt) => mask(receipt, GetCallsStatusReceiptStruct))
-    : null;
-
-  res.result = { status, receipts };
+  res.result = await getCallsStatus(id, req);
 }

--- a/src/methods/wallet-get-calls-status.ts
+++ b/src/methods/wallet-get-calls-status.ts
@@ -13,6 +13,14 @@ import { validateParams } from '../utils/validation';
 
 const GetCallsStatusStruct = tuple([StrictHexStruct]);
 
+export enum GetCallsStatusCode {
+  PENDING = 100,
+  CONFIRMED = 200,
+  FAILED_OFFCHAIN = 400,
+  REVERTED = 500,
+  REVERTED_PARTIAL = 600,
+}
+
 export type GetCallsStatusParams = Infer<typeof GetCallsStatusStruct>;
 
 export type GetCallsStatusResult = {

--- a/src/methods/wallet-get-calls-status.ts
+++ b/src/methods/wallet-get-calls-status.ts
@@ -34,7 +34,7 @@ export type GetCallsStatusResult = {
       data: Hex;
       topics: Hex[];
     }[];
-    status: Hex;
+    status: '0x0' | '0x1';
     blockHash: Hex;
     blockNumber: Hex;
     gasUsed: Hex;
@@ -46,7 +46,7 @@ export type GetCallsStatusResult = {
 export type GetCallsStatusHook = (
   id: GetCallsStatusParams[0],
   req: JsonRpcRequest,
-) => Promise<GetCallsStatusResult[]>;
+) => Promise<GetCallsStatusResult>;
 
 export async function walletGetCallsStatus(
   req: JsonRpcRequest,

--- a/src/methods/wallet-get-capabilities.test.ts
+++ b/src/methods/wallet-get-capabilities.test.ts
@@ -9,6 +9,8 @@ import type {
 import { walletGetCapabilities } from './wallet-get-capabilities';
 
 const ADDRESS_MOCK = '0x123abc123abc123abc123abc123abc123abc123a';
+const CHAIN_ID_MOCK = '0x1';
+const CHAIN_ID_2_MOCK = '0x2';
 
 const RESULT_MOCK = {
   testCapability: {
@@ -18,10 +20,10 @@ const RESULT_MOCK = {
 
 const REQUEST_MOCK = {
   params: [ADDRESS_MOCK],
-} as unknown as JsonRpcRequest<GetCapabilitiesParams>;
+};
 
 describe('wallet_getCapabilities', () => {
-  let request: JsonRpcRequest<GetCapabilitiesParams>;
+  let request: JsonRpcRequest;
   let params: GetCapabilitiesParams;
   let response: PendingJsonRpcResponse<GetCapabilitiesResult>;
   let getCapabilitiesMock: jest.MockedFunction<GetCapabilitiesHook>;
@@ -35,7 +37,7 @@ describe('wallet_getCapabilities', () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
-    request = klona(REQUEST_MOCK);
+    request = klona(REQUEST_MOCK) as JsonRpcRequest;
     params = request.params as GetCapabilitiesParams;
     response = {} as PendingJsonRpcResponse<GetCapabilitiesResult>;
 
@@ -44,12 +46,27 @@ describe('wallet_getCapabilities', () => {
 
   it('calls hook', async () => {
     await callMethod();
-    expect(getCapabilitiesMock).toHaveBeenCalledWith(params[0], request);
+    expect(getCapabilitiesMock).toHaveBeenCalledWith(
+      params[0],
+      undefined,
+      request,
+    );
+  });
+
+  it('calls hook with chain IDs', async () => {
+    request.params = [ADDRESS_MOCK, [CHAIN_ID_MOCK, CHAIN_ID_2_MOCK]];
+
+    await callMethod();
+
+    expect(getCapabilitiesMock).toHaveBeenCalledWith(
+      params[0],
+      [CHAIN_ID_MOCK, CHAIN_ID_2_MOCK],
+      request,
+    );
   });
 
   it('returns capabilities from hook', async () => {
     await callMethod();
-
     expect(response.result).toStrictEqual(RESULT_MOCK);
   });
 

--- a/src/methods/wallet-get-capabilities.ts
+++ b/src/methods/wallet-get-capabilities.ts
@@ -1,23 +1,27 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Infer } from '@metamask/superstruct';
-import { tuple } from '@metamask/superstruct';
+import { array, optional, tuple } from '@metamask/superstruct';
 import type {
   Hex,
   Json,
   JsonRpcRequest,
   PendingJsonRpcResponse,
 } from '@metamask/utils';
-import { HexChecksumAddressStruct } from '@metamask/utils';
+import { StrictHexStruct, HexChecksumAddressStruct } from '@metamask/utils';
 
 import { validateParams } from '../utils/validation';
 
-const GetCapabilitiesStruct = tuple([HexChecksumAddressStruct]);
+const GetCapabilitiesStruct = tuple([
+  HexChecksumAddressStruct,
+  optional(array(StrictHexStruct)),
+]);
 
 export type GetCapabilitiesParams = Infer<typeof GetCapabilitiesStruct>;
 export type GetCapabilitiesResult = Record<Hex, Record<string, Json>>;
 
 export type GetCapabilitiesHook = (
-  address: Hex,
+  address: GetCapabilitiesParams[0],
+  chainIds: GetCapabilitiesParams[1],
   req: JsonRpcRequest,
 ) => Promise<GetCapabilitiesResult>;
 
@@ -37,7 +41,8 @@ export async function walletGetCapabilities(
   validateParams(req.params, GetCapabilitiesStruct);
 
   const address = req.params[0];
-  const capabilities = await getCapabilities(address, req);
+  const chainIds = req.params[1];
+  const capabilities = await getCapabilities(address, chainIds, req);
 
   res.result = capabilities;
 }

--- a/src/methods/wallet-send-calls.test.ts
+++ b/src/methods/wallet-send-calls.test.ts
@@ -128,6 +128,7 @@ describe('wallet_sendCalls', () => {
             [Error: Invalid params
 
             0 > from - Expected a string, but received: undefined
+            0 > chainId - Expected a string, but received: undefined
             0 > calls - Expected an array value, but received: undefined]
           `);
   });

--- a/src/methods/wallet-send-calls.test.ts
+++ b/src/methods/wallet-send-calls.test.ts
@@ -3,6 +3,7 @@ import { klona } from 'klona';
 
 import type {
   ProcessSendCallsHook,
+  SendCalls,
   SendCallsParams,
 } from './wallet-send-calls';
 import { walletSendCalls } from './wallet-send-calls';
@@ -66,9 +67,23 @@ describe('wallet_sendCalls', () => {
     expect(response.result).toStrictEqual(ID_MOCK);
   });
 
-  it('supports capabilities', async () => {
-    params[0].capabilities = { test: 'value' };
+  it('supports top-level capabilities', async () => {
+    params[0].capabilities = {
+      'test-capability': { test: 'value', optional: true },
+    } as SendCalls['capabilities'];
+
     await callMethod();
+
+    expect(processSendCallsMock).toHaveBeenCalledWith(params[0], request);
+  });
+
+  it('supports call capabilities', async () => {
+    params[0].calls[0].capabilities = {
+      'test-capability': { test: 'value', optional: false },
+    } as SendCalls['capabilities'];
+
+    await callMethod();
+
     expect(processSendCallsMock).toHaveBeenCalledWith(params[0], request);
   });
 
@@ -107,13 +122,15 @@ describe('wallet_sendCalls', () => {
     params[0].from = '123' as never;
     params[0].chainId = 123 as never;
     params[0].calls = '123' as never;
+    params[0].capabilities = '123' as never;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
             [Error: Invalid params
 
             0 > from - Expected a string matching \`/^0x[0-9a-fA-F]{40}$/\` but received "123"
             0 > chainId - Expected a string, but received: 123
-            0 > calls - Expected an array value, but received: "123"]
+            0 > calls - Expected an array value, but received: "123"
+            0 > capabilities - Expected an object, but received: "123"]
           `);
   });
 
@@ -121,13 +138,15 @@ describe('wallet_sendCalls', () => {
     params[0].calls[0].data = 123 as never;
     params[0].calls[0].to = 123 as never;
     params[0].calls[0].value = 123 as never;
+    params[0].calls[0].capabilities = '123' as never;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
             [Error: Invalid params
 
             0 > calls > 0 > to - Expected a string, but received: 123
             0 > calls > 0 > data - Expected a string, but received: 123
-            0 > calls > 0 > value - Expected a string, but received: 123]
+            0 > calls > 0 > value - Expected a string, but received: 123
+            0 > calls > 0 > capabilities - Expected an object, but received: "123"]
           `);
   });
 

--- a/src/methods/wallet-send-calls.ts
+++ b/src/methods/wallet-send-calls.ts
@@ -36,7 +36,7 @@ const SendCallsStruct = tuple([
     version: nonempty(string()),
     id: optional(StrictHexStruct),
     from: HexChecksumAddressStruct,
-    chainId: optional(StrictHexStruct),
+    chainId: StrictHexStruct,
     calls: array(
       object({
         to: optional(HexChecksumAddressStruct),

--- a/src/methods/wallet-send-calls.ts
+++ b/src/methods/wallet-send-calls.ts
@@ -1,6 +1,8 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Infer } from '@metamask/superstruct';
 import {
+  boolean,
+  record,
   nonempty,
   type,
   string,
@@ -10,6 +12,7 @@ import {
   tuple,
 } from '@metamask/superstruct';
 import type {
+  Hex,
   Json,
   JsonRpcRequest,
   PendingJsonRpcResponse,
@@ -21,6 +24,13 @@ import {
   validateParams,
 } from '../utils/validation';
 
+const CapabilitiesStruct = record(
+  string(),
+  type({
+    optional: optional(boolean()),
+  }),
+);
+
 const SendCallsStruct = tuple([
   object({
     version: nonempty(string()),
@@ -31,19 +41,25 @@ const SendCallsStruct = tuple([
         to: optional(HexChecksumAddressStruct),
         data: optional(StrictHexStruct),
         value: optional(StrictHexStruct),
+        capabilities: optional(CapabilitiesStruct),
       }),
     ),
-    capabilities: optional(type({})),
+    capabilities: optional(CapabilitiesStruct),
   }),
 ]);
 
 export type SendCallsParams = Infer<typeof SendCallsStruct>;
 export type SendCalls = SendCallsParams[0];
 
+export type SendCallsResult = {
+  id: Hex;
+  capabilities?: Record<string, Json>;
+};
+
 export type ProcessSendCallsHook = (
   sendCalls: SendCalls,
   req: JsonRpcRequest,
-) => Promise<string>;
+) => Promise<SendCallsResult>;
 
 export async function walletSendCalls(
   req: JsonRpcRequest,

--- a/src/methods/wallet-send-calls.ts
+++ b/src/methods/wallet-send-calls.ts
@@ -34,6 +34,7 @@ const CapabilitiesStruct = record(
 const SendCallsStruct = tuple([
   object({
     version: nonempty(string()),
+    id: optional(StrictHexStruct),
     from: HexChecksumAddressStruct,
     chainId: optional(StrictHexStruct),
     calls: array(

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -13,7 +13,7 @@ import type {
   Hex,
 } from '@metamask/utils';
 
-import type { GetTransactionReceiptsByBatchIdHook } from './methods/wallet-get-calls-status';
+import type { GetCallsStatusHook } from './methods/wallet-get-calls-status';
 import { walletGetCallsStatus } from './methods/wallet-get-calls-status';
 import type { GetCapabilitiesHook } from './methods/wallet-get-capabilities';
 import { walletGetCapabilities } from './methods/wallet-get-capabilities';
@@ -59,8 +59,8 @@ export type TypedMessageV1Params = Omit<TypedMessageParams, 'data'> & {
 
 export interface WalletMiddlewareOptions {
   getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
+  getCallsStatus?: GetCallsStatusHook;
   getCapabilities?: GetCapabilitiesHook;
-  getTransactionReceiptsByBatchId?: GetTransactionReceiptsByBatchIdHook;
   processDecryptMessage?: (
     msgParams: MessageParams,
     req: JsonRpcRequest,
@@ -101,8 +101,8 @@ export interface WalletMiddlewareOptions {
 
 export function createWalletMiddleware({
   getAccounts,
+  getCallsStatus,
   getCapabilities,
-  getTransactionReceiptsByBatchId,
   processDecryptMessage,
   processEncryptionPublicKey,
   processPersonalMessage,
@@ -145,7 +145,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
     ),
     wallet_getCallsStatus: createAsyncMiddleware(async (params, req) =>
       walletGetCallsStatus(params, req, {
-        getTransactionReceiptsByBatchId,
+        getCallsStatus,
       }),
     ),
   });


### PR DESCRIPTION
Update the EIP-5792 support following changes to the specification.

Specifically:

- `wallet_sendCalls`
  - Support optional custom `id`.
  - Support optional `capabilities` per call.
  - Support `optional` property in capabilities.
  - Return object containing `id` and optional `capabilities`. 
- `wallet_getCallsStatus`
  - Expect hexadecimal `id`.
  - Add `id`, `version`, and optional `capabilities` to result.
  - Change `status` to number.
  - Provider current codes in `GetCallsStatusCode` enum.
  - Use more generic `GetCallsStatusHook`.
- `wallet_getCapabilities`
  - Support optional `chainIds` argument.