### PR TITLE
Sync GitHub workflows with module template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                   @MetaMask/wallet-framework-engineers
+*                                    @MetaMask/wallet-framework-engineers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:
+
+* What is the current state of things and why does it need to change?
+* What is the solution your changes offer and how does it work?
+
+Are there any issues or other links reviewers should consult to understand this pull request better? For instance:
+
+* Fixes #12345
+* See: #67890
+-->

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -7,32 +7,30 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-      - name: Install Yarn dependencies
-        run: yarn --immutable
-
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+          cache-node-modules: ${{ matrix.node-version == '22.x' }}
+
+  build:
+    name: Build
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -44,27 +42,18 @@ jobs:
 
   lint:
     name: Lint
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
       - run: yarn lint
-      - name: Validate RC changelog
-        if: ${{ startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate --rc
-      - name: Validate changelog
-        if: ${{ !startsWith(github.head_ref, 'release/') }}
-        run: yarn auto-changelog validate
       - name: Require clean working directory
         shell: bash
         run: |
@@ -75,21 +64,44 @@ jobs:
 
   test:
     name: Test
+    needs: prepare
     runs-on: ubuntu-latest
-    needs:
-      - prepare
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
       - run: yarn test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  compatibility-test:
+    name: Compatibility test
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies via Yarn
+        run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
+      - run: yarn test
+      - name: Restore lockfile
+        run: git restore yarn.lock
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -8,7 +8,7 @@ on:
         default: 'main'
         required: true
       release-type:
-        description: 'A SemVer version diff, i.e. major, minor, patch, prerelease etc. Mutually exclusive with "release-version".'
+        description: 'A SemVer version diff, i.e. major, minor, or patch. Mutually exclusive with "release-version".'
         required: false
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'
@@ -21,21 +21,22 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          # This is to guarantee that the most recent tag is fetched.
-          # This can be configured to a more reasonable value by consumers.
+          is-high-risk-environment: true
+
+          # This is to guarantee that the most recent tag is fetched. This can
+          # be configured to a more reasonable value by consumers.
           fetch-depth: 0
+
           # We check out the specified branch, which will be used as the base
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-      - uses: MetaMask/action-create-release-pr@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: MetaMask/action-create-release-pr@v4
         with:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,29 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
+        with:
+          is-high-risk-environment: false
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color
         shell: bash
+
+  analyse-code:
+    name: Code scanner
+    needs: check-workflows
+    uses: ./.github/workflows/security-code-scanner.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
 
   build-lint-test:
     name: Build, lint, and test
@@ -28,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-workflows
+      - analyse-code
       - build-lint-test
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
@@ -73,3 +89,4 @@ jobs:
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,88 +5,74 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
-
+      SLACK_WEBHOOK_URL:
+        required: true
 jobs:
   publish-release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-      - uses: MetaMask/action-publish-release@v2
+      - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install
-        run: |
-          yarn install
-          yarn build
-      - uses: actions/cache@v3
-        id: restore-build
+      - run: yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
           path: |
             ./dist
             ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
 
   publish-npm-dry-run:
-    runs-on: ubuntu-latest
     needs: publish-release
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        id: restore-build
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v5
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          subteam: S042S7RE4AE # @metamask-npm-publishers
         env:
           SKIP_PREPACK: true
 
   publish-npm:
-    environment: npm-publish
-    runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
+          is-high-risk-environment: true
           ref: ${{ github.sha }}
-      - uses: actions/cache@v3
-        id: restore-build
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-          key: ${{ github.sha }}
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v5
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:
           SKIP_PREPACK: true
-
-  get-release-version:
-    runs-on: ubuntu-latest
-    needs: publish-npm
-    outputs:
-      RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-      - id: get-release-version
-        shell: bash
-        run: ./scripts/get.sh ".version" "RELEASE_VERSION"

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -1,23 +1,24 @@
 name: MetaMask Security Code Scanner
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN:
+        required: false
+      APPSEC_BOT_SLACK_WEBHOOK:
+        required: false
   workflow_dispatch:
 
 jobs:
   run-security-scan:
+    name: Run security scan
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
     steps:
-      - name: MetaMask Security Code Scanner
+      - name: Analyse code
         uses: MetaMask/action-security-code-scanner@v1
         with:
           repo: ${{ github.repository }}


### PR DESCRIPTION
## Description

This commit ensures that the GitHub workflows (minus anything documentation-related) and other files in `.github` are synced with the module template.

- Add pull request template
- Add compatibility test
- Use `checkout-and-setup` action, avoid the use of `actions/cache` for publishing
- Bump to `action-create-release-pr` v4
  - This may address a bug where if the changelog is updated fully before attempting to create an RC, the Create Pull Request workflow cannot be run. v1 is likely using an old version of `@metamask/auto-changelog`.
- Bump to `action-publish-release` v3
- Bump to `action-npm-publish` v5
- Bump to `action-security-code-scanner` v1
- Notify Slack when new release is ready for approval
- Remove unused `get-release-version` step

## References

Compare the changes in this commit with the [`.github` directory in the module template](https://github.com/MetaMask/metamask-module-template/tree/963c11dab6b26bbd782461284776f4cf0a85dde9/.github).