### PR TITLE
fetch: Treat non-standard JSON-RPC errors as standard

### DIFF
--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -84,8 +84,8 @@ describe('createFetchMiddleware', () => {
     );
   });
 
-  describe('if the request to the service returns a successful JSON-RPC response', () => {
-    it('includes the `result` field from the RPC service in its own response', async () => {
+  describe('if the response from the service does not contain an `error` field', () => {
+    it('returns a successful JSON-RPC response containing the value of the `result` field', async () => {
       const rpcService = buildRpcService();
       jest.spyOn(rpcService, 'request').mockResolvedValue({
         id: 1,
@@ -113,8 +113,8 @@ describe('createFetchMiddleware', () => {
     });
   });
 
-  describe('if the request to the service returns a unsuccessful JSON-RPC response', () => {
-    it('includes the `error` field from the service in a new internal JSON-RPC error', async () => {
+  describe('if the response from the service contains an `error` field with a standard JSON-RPC error object', () => {
+    it('returns an unsuccessful JSON-RPC response containing the error, wrapped in an "internal" error', async () => {
       const rpcService = buildRpcService();
       jest.spyOn(rpcService, 'request').mockResolvedValue({
         id: 1,
@@ -137,7 +137,7 @@ describe('createFetchMiddleware', () => {
         params: [],
       });
 
-      expect(result).toMatchObject({
+      expect(result).toStrictEqual({
         id: 1,
         jsonrpc: '2.0',
         error: {
@@ -154,8 +154,63 @@ describe('createFetchMiddleware', () => {
     });
   });
 
-  describe('if the request to the service throws', () => {
-    it('includes the message and stack of the error in a new JSON-RPC error', async () => {
+  describe('if the response from the service contains an `error` field with a non-standard JSON-RPC error object', () => {
+    it('returns an unsuccessful JSON-RPC response containing the error, wrapped in an "internal" error', async () => {
+      const rpcService = buildRpcService();
+      jest.spyOn(rpcService, 'request').mockResolvedValue({
+        id: 1,
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          data: {
+            foo: 'bar',
+          },
+          message: 'VM Exception while processing transaction: revert',
+          // @ts-expect-error The `name` property is not strictly part of the
+          // JSON-RPC error object.
+          name: 'RuntimeError',
+          stack:
+            'RuntimeError: VM Exception while processing transaction: revert at exactimate (/Users/elliot/code/metamask/metamask-mobile/node_modules/ganache/dist/node/webpack:/Ganache/ethereum/ethereum/lib/src/helpers/gas-estimator.js:257:23)',
+        },
+      });
+      const middleware = createFetchMiddleware({
+        rpcService,
+      });
+
+      const engine = new JsonRpcEngine();
+      engine.push(middleware);
+      const result = await engine.handle({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_chainId',
+        params: [],
+      });
+
+      expect(result).toStrictEqual({
+        id: 1,
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal JSON-RPC error.',
+          stack: expect.stringContaining('Internal JSON-RPC error.'),
+          data: {
+            code: -32000,
+            data: {
+              foo: 'bar',
+            },
+            message: 'VM Exception while processing transaction: revert',
+            name: 'RuntimeError',
+            stack:
+              'RuntimeError: VM Exception while processing transaction: revert at exactimate (/Users/elliot/code/metamask/metamask-mobile/node_modules/ganache/dist/node/webpack:/Ganache/ethereum/ethereum/lib/src/helpers/gas-estimator.js:257:23)',
+            cause: null,
+          },
+        },
+      });
+    });
+  });
+
+  describe('if the request throws', () => {
+    it('returns an unsuccessful JSON-RPC response containing the error', async () => {
       const rpcService = buildRpcService();
       jest.spyOn(rpcService, 'request').mockRejectedValue(new Error('oops'));
       const middleware = createFetchMiddleware({
@@ -171,11 +226,12 @@ describe('createFetchMiddleware', () => {
         params: [],
       });
 
-      expect(result).toMatchObject({
+      expect(result).toStrictEqual({
         id: 1,
         jsonrpc: '2.0',
         error: {
           code: -32603,
+          message: 'oops',
           data: {
             cause: {
               message: 'oops',

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,7 +2,6 @@ import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type { JsonRpcError, DataWithOptionalCause } from '@metamask/rpc-errors';
 import { rpcErrors } from '@metamask/rpc-errors';
-import { isJsonRpcFailure } from '@metamask/utils';
 import type { Json, JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
 import type { AbstractRpcService, Block } from './types';
@@ -150,7 +149,11 @@ function createFetchMiddlewareWithRpcService({
         },
       );
 
-      if (isJsonRpcFailure(jsonRpcResponse)) {
+      // NOTE: We intentionally do not test to see if `jsonRpcResponse.error` is
+      // strictly a JSON-RPC error response as per
+      // <https://www.jsonrpc.org/specification#error_object> to account for
+      // Ganache returning error objects with extra properties such as `name`
+      if ('error' in jsonRpcResponse) {
         throw rpcErrors.internal({
           data: jsonRpcResponse.error,
         });


### PR DESCRIPTION
The [JSON-RPC specification](https://www.jsonrpc.org/specification) says that a JSON-RPC-compliant server must return a response with either a `result` or an `error` field, and if an `error` field is present, then it must be an object with the following fields: `code`, `message`, and `data`. The `isJsonRpcError` from `@metamask/utils` (via the [`JsonRpcError` type][2]) not only checks for the three aforementioned properties, but also allows an additional, optional `stack` property to be present. However, it does not allow any other properties beyond the four declared.

This is a problem because the new implementation of the `fetch` middleware makes use of this function to know how to handle errors, and as a result, non-standard error responses are being treated as successful responses (and the errors themselves are being discarded). This is particularly noticeable when using Ganache as a local RPC server, because it produces such non-standard error responses, such as when a transaction fails.

To correct this bug, this commit brings the error-handling code in the `fetch` middleware closer to the original implementation, and updates the tests to ensure that Ganache errors are treated correctly.

[1]: https://www.jsonrpc.org/specification
[2]: https://github.com/MetaMask/utils/blob/55b22a77e75641c4c8b05eec73982084ac9e7332/src/json.ts#L301