### PR TITLE
feat: support version 2.0.0 of EIP-5792

### DIFF
--- a/src/methods/wallet-get-calls-status.ts
+++ b/src/methods/wallet-get-calls-status.ts
@@ -28,6 +28,7 @@ export type GetCallsStatusResult = {
   id: Hex;
   chainId: Hex;
   status: number;
+  atomic: boolean;
   receipts?: {
     logs: {
       address: Hex;

--- a/src/methods/wallet-get-capabilities.ts
+++ b/src/methods/wallet-get-capabilities.ts
@@ -9,7 +9,10 @@ import type {
 } from '@metamask/utils';
 import { StrictHexStruct, HexChecksumAddressStruct } from '@metamask/utils';
 
-import { validateParams } from '../utils/validation';
+import {
+  validateAndNormalizeKeyholder,
+  validateParams,
+} from '../utils/validation';
 
 const GetCapabilitiesStruct = tuple([
   HexChecksumAddressStruct,
@@ -29,8 +32,10 @@ export async function walletGetCapabilities(
   req: JsonRpcRequest,
   res: PendingJsonRpcResponse<Json>,
   {
+    getAccounts,
     getCapabilities,
   }: {
+    getAccounts: (req: JsonRpcRequest) => Promise<string[]>;
     getCapabilities?: GetCapabilitiesHook;
   },
 ): Promise<void> {
@@ -42,6 +47,11 @@ export async function walletGetCapabilities(
 
   const address = req.params[0];
   const chainIds = req.params[1];
+
+  await validateAndNormalizeKeyholder(address, req, {
+    getAccounts,
+  });
+
   const capabilities = await getCapabilities(address, chainIds, req);
 
   res.result = capabilities;

--- a/src/methods/wallet-send-calls.test.ts
+++ b/src/methods/wallet-send-calls.test.ts
@@ -21,6 +21,7 @@ const REQUEST_MOCK = {
       version: '1.0',
       from: ADDRESS_MOCK,
       chainId: HEX_MOCK,
+      atomicRequired: true,
       calls: [
         {
           to: ADDRESS_MOCK,
@@ -123,12 +124,13 @@ describe('wallet_sendCalls', () => {
     params[0].from = undefined as never;
     params[0].chainId = undefined as never;
     params[0].calls = undefined as never;
+    params[0].atomicRequired = undefined as never;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
             [Error: Invalid params
 
-            0 > from - Expected a string, but received: undefined
             0 > chainId - Expected a string, but received: undefined
+            0 > atomicRequired - Expected a value of type \`boolean\`, but received: \`undefined\`
             0 > calls - Expected an array value, but received: undefined]
           `);
   });
@@ -139,6 +141,7 @@ describe('wallet_sendCalls', () => {
     params[0].chainId = 123 as never;
     params[0].calls = '123' as never;
     params[0].capabilities = '123' as never;
+    params[0].atomicRequired = 123 as never;
 
     await expect(callMethod()).rejects.toMatchInlineSnapshot(`
             [Error: Invalid params
@@ -146,6 +149,7 @@ describe('wallet_sendCalls', () => {
             0 > id - Expected a string, but received: 123
             0 > from - Expected a string matching \`/^0x[0-9a-fA-F]{40}$/\` but received "123"
             0 > chainId - Expected a string, but received: 123
+            0 > atomicRequired - Expected a value of type \`boolean\`, but received: \`123\`
             0 > calls - Expected an array value, but received: "123"
             0 > capabilities - Expected an object, but received: "123"]
           `);

--- a/src/methods/wallet-send-calls.ts
+++ b/src/methods/wallet-send-calls.ts
@@ -35,8 +35,9 @@ const SendCallsStruct = tuple([
   object({
     version: nonempty(string()),
     id: optional(StrictHexStruct),
-    from: HexChecksumAddressStruct,
+    from: optional(HexChecksumAddressStruct),
     chainId: StrictHexStruct,
+    atomicRequired: boolean(),
     calls: array(
       object({
         to: optional(HexChecksumAddressStruct),
@@ -81,9 +82,11 @@ export async function walletSendCalls(
 
   const params = req.params[0];
 
-  const from = await validateAndNormalizeKeyholder(params.from, req, {
-    getAccounts,
-  });
+  const from = params.from
+    ? await validateAndNormalizeKeyholder(params.from, req, {
+        getAccounts,
+      })
+    : undefined;
 
   const sendCalls: SendCalls = {
     ...params,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -42,7 +42,7 @@ export function validateParams<ParamsType>(
   const [error] = validate(value, struct);
 
   if (error) {
-    throw rpcErrors.invalidInput(
+    throw rpcErrors.invalidParams(
       formatValidationError(error, `Invalid params`),
     );
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -138,7 +138,7 @@ WalletMiddlewareOptions): JsonRpcMiddleware<any, Block> {
 
     // EIP-5792
     wallet_getCapabilities: createAsyncMiddleware(async (params, req) =>
-      walletGetCapabilities(params, req, { getCapabilities }),
+      walletGetCapabilities(params, req, { getAccounts, getCapabilities }),
     ),
     wallet_sendCalls: createAsyncMiddleware(async (params, req) =>
       walletSendCalls(params, req, { getAccounts, processSendCalls }),


### PR DESCRIPTION
Update types and validations to support version 2.0.0 of EIP-5792 specification.

Specifically:

- Add `atomicRequired` property to `SendCallsStruct`.
- Add `atomic` property to `GetCallsStatusResult`.
- Support optional `from` in `wallet_sendCalls`.
- Validate `address` in `wallet_getCapabilities` is added to wallet.
- Use `-32602` code for schema errors.