### PR TITLE
refactor!: Remove `ethersProviderAsMiddleware`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** Remove `ethersProviderAsMiddleware` ([#415](https://github.com/MetaMask/eth-json-rpc-middleware/pull/415))
+
 ## [18.0.0]
 
 ### Changed

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -3,11 +3,7 @@ import {
   createAsyncMiddleware,
   type JsonRpcMiddleware,
 } from '@metamask/json-rpc-engine';
-import type {
-  Json,
-  JsonRpcParams,
-  PendingJsonRpcResponse,
-} from '@metamask/utils';
+import type { Json, JsonRpcParams } from '@metamask/utils';
 
 export function providerAsMiddleware(
   provider: SafeEventEmitterProvider,

--- a/src/providerAsMiddleware.ts
+++ b/src/providerAsMiddleware.ts
@@ -16,25 +16,3 @@ export function providerAsMiddleware(
     res.result = await provider.request(req);
   });
 }
-
-export function ethersProviderAsMiddleware(
-  provider: SafeEventEmitterProvider,
-): JsonRpcMiddleware<JsonRpcParams, Json> {
-  return (req, res, _next, end) => {
-    // send request to provider
-    provider.send(
-      req,
-      (err: unknown, providerRes: PendingJsonRpcResponse<any>) => {
-        // forward any error
-        if (err) {
-          // TODO: Remove this cast when next major `@metamask/json-rpc-engine` release is out
-          // The next release changes how errors are propogated.
-          return end(err as Error);
-        }
-        // copy provider response onto original response
-        Object.assign(res, providerRes);
-        return end();
-      },
-    );
-  };
-}


### PR DESCRIPTION
We do not use `ethersProviderAsMiddleware` internally, which additionally relies on a method of our internal, non-standard provider type that we are trying to get rid of. In consequence of this, this PR removes this function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `ethersProviderAsMiddleware` and documents it as a breaking change in the changelog.
> 
> - **Source (`src/providerAsMiddleware.ts`)**:
>   - Remove `ethersProviderAsMiddleware` and related `PendingJsonRpcResponse` import.
> - **Docs (`CHANGELOG.md`)**:
>   - Add Unreleased note under Removed: **BREAKING** removal of `ethersProviderAsMiddleware`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54489252e540ca9524e3fa8558c65a21e3b50071. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->