### PR TITLE
docs: Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # eth-json-rpc-middleware
 
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><p align="center">This package is currently being migrated to our <a href="https://github.com/MetaMask/core"><code>core</code></a> monorepo. Please do not make any commits to this repository while this migration is taking place, as they will not be transferred over.</p></td></tr></table>
+<table>
+  <tr>
+    <td>
+      <p align="center"><b>⚠️ PLEASE READ ⚠️</b></p>
+      <p align="center">
+        This package has been migrated to our
+        <a href="https://github.com/MetaMask/core"><code>core</code></a>
+        monorepo, and this repository has been archived. Please note that all
+        future development and feature releases will take place in the
+        <a href="https://github.com/MetaMask/core"><code>core</code></a>
+        repository.
+      </p>
+    </td>
+  </tr>
+</table>
 
 Ethereum-related middleware for [`json-rpc-engine`](https://github.com/MetaMask/json-rpc-engine).
 


### PR DESCRIPTION
Adds the archive notice to the README for this repository.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README to state the package is migrated and the repo is archived, directing future development to the core monorepo.
> 
> - **Docs**:
>   - **README**: Replaces migration-in-progress notice with an archive/migration notice, clarifying the package now lives in `https://github.com/MetaMask/core` and future development occurs there.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3373d7885be693f0de7e4ca4517dc0b44066bf46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->